### PR TITLE
Add swizzling support (xyzw and rgba)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ keywords = [ "linear", "algebra", "matrix", "vector", "math" ]
 name = "aljabar"
 
 [dependencies]
+paste = "0.1"

--- a/README.md
+++ b/README.md
@@ -226,6 +226,43 @@ a number of convenience methods:
 A `Matrix` that implements `Mul<Self>`. Has a `diagonal` and in the future a 
 possible inverse.
 
+### `Swizzle`
+
+Provides swizzling support for both the `xyzw` or `rgba` conventions.
+All possible combinations of the first four elements of a vector are
+supported. Single-element swizzle functions return scalar results,
+multi-element swizzle functions return vector results of the appropriate
+size based on the number of selected elements.
+
+```rust
+let a = vec4( 0.0, 1.0, 2.0, 3.0 );
+
+// A single element is returned as a scalar.
+assert_eq!(1.0, a.y());
+
+// Multiple elements are returned as a vector.
+assert_eq!(vec3(2.0, 0.0, 3.0), a.zxw());
+
+// The same element can be selected more than once.
+assert_eq!(vec2(0.0, 0.0), a.rr());
+```
+
+Mixing `xyzw` and `rgba` swizzle conventions is not allowed.
+
+```rust
+let a = vec4( 0.0, 1.0, 2.0, 3.0 );
+let b = a.rgzw(); // Does not compile.
+```
+
+Swizzling is supported on vectors of length less than 4. Attempting to access
+elements past the length of the vector is a compile error.
+
+```rust
+let a = vec3!(0.0, 1.0, 2.0);
+let b = a.xyz(); // OK, only accesses the first 3 elements.
+let c = a.rgba(); // Compile error, attempts to access missing 4th element.
+```
+
 ## Limitations
 
 Individual component access isn't implemented for vectors and most likely will 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,6 @@ macro_rules! swizzle {
     // third level, specifying the third letter.
     ($a:ident, $b:ident, $x:ident, $y:ident, $z:ident, $w:ident) => {
         paste::item! {
-            // #[doc = $comment]
             fn [< $a $b >](&self) -> Vector<T, 2> {
                 Vector::<T, 2>::from([
                     self.$a(),
@@ -296,7 +295,6 @@ macro_rules! swizzle {
     // fourth level, specifying the fourth letter.
     ($a:ident, $b:ident, $c:ident, $x:ident, $y:ident, $z:ident, $w:ident) => {
         paste::item! {
-            // #[doc = $comment]
             fn [< $a $b $c >](&self) -> Vector<T, 3> {
                 Vector::<T, 3>::from([
                     self.$a(),
@@ -318,7 +316,6 @@ macro_rules! swizzle {
     // because it already has all the names assigned.
     ($a:ident, $b:ident, $c:ident, $d:ident) => {
         paste::item! {
-            // #[doc = $comment]
             fn [< $a $b $c $d >](&self) -> Vector<T, 4> {
                 Vector::<T, 4>::from([
                     self.$a(),
@@ -331,7 +328,8 @@ macro_rules! swizzle {
     };
 }
 
-/// Provides [swizzling](https://en.wikipedia.org/wiki/Swizzling_(computer_graphics)) support for up to four elements. Swizzling is a technique for easily
+/// Provides [swizzling](https://en.wikipedia.org/wiki/Swizzling_(computer_graphics))
+/// support for up to four elements. Swizzling is a technique for easily
 /// rearranging and accessing elements of a vector, used commonly in graphics shader
 /// programming. Swizzling is available on vectors whose element type is Copy.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ macro_rules! swizzle {
 /// than length four and want to manipulate their elements, you must do so manually.
 ///
 /// Because swizzling is often used in compute graphics contexts when dealing with colors,
-/// both 'xyzw' and 'rgba' element names are available. They cannot however be mixed.
+/// both 'xyzw' and 'rgba' element names are available.
 ///
 /// | Element Index | xyzw Name | rgba Name |
 /// |---------------|-----------|-----------|
@@ -354,6 +354,19 @@ macro_rules! swizzle {
 /// It is a compilation error to attempt to access an element beyond the bounds of a vector.
 /// For example, `vector![1, 2].z()` would fail because `z()` is only available on vectors of
 /// length 3 or greater.
+///
+/// ```compile_fail
+/// let v = vector![1, 2].z(); // Fails to compile.
+/// ```
+///
+/// Mixing
+///
+/// ```compile_fail
+/// let v = vector![1, 2, 3, 4];
+/// let xy = v.xy(); // OK, only uses xyzw names.
+/// let rg = v.rg(); // OK, only uses rgba names.
+/// let bad = v.xyrg(); // Compile error, mixes xyzw and rgba names.
+/// ```
 ///
 /// # Examples
 ///
@@ -376,7 +389,7 @@ macro_rules! swizzle {
 /// ```ignore
 /// let v = vector![1, 2, 3, 4].xxzz();
 /// ```
-pub trait Swizzle<T> {
+pub trait Swizzle<T> : Sized {
     fn x(&self) -> T;
     fn y(&self) -> T;
     fn z(&self) -> T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! and specialization.
 //!
 //! It is not the specific goal of this project to be useful in any sense, but
-//! hopefully it will end up being roughly compatible with cgmath.
+//! hopefully it will end up being roughly compatible with cgmath. 
 //!
 //! The performance of Aljabar is currently probably pretty bad. I have yet to
 //! test it, but let's just say I haven't gotten very far on the matrix
@@ -207,7 +207,7 @@ impl Real for f64 {
 
 /// N-element vector.
 ///
-/// Vectors can be constructed from arrays of any type and size. There are
+/// Vectors can be constructed from arrays of any type and size. There are 
 /// convenience constructor functions provided for the most common sizes.
 ///
 /*
@@ -217,7 +217,7 @@ impl Real for f64 {
 /// let a Vector::<u32, 4> = vec4( 0u32, 1, 2, 3 );
 /// /*
 /// assert_eq!(
-///     a,
+///     a, 
 ///     Vector::<u32, 4>::from([ 0u32, 1, 2, 3 ])
 /// );
 /// */
@@ -474,7 +474,7 @@ pub fn vec4<T>(x: T, y: T, z: T, w: T) -> Vector4<T> {
     Vector4::<T>::from([ x, y, z, w ])
 }
 
-/// 5-element vector.
+/// 5-element vector. 
 pub type Vector5<T> = Vector<T, 5>;
 
 impl<T, const N: usize> From<[T; N]> for Vector<T, {N}> {
@@ -752,7 +752,7 @@ where
     }
 }
 
-/// Scalar divide assign
+/// Scalar divide assign 
 impl<A, B, const N: usize> DivAssign<B> for Vector<A, {N}>
 where
     A: DivAssign<B>,
@@ -799,7 +799,7 @@ where
         Sub<Self::Scalar, Output = Self::Scalar> +
         Mul<Self::Scalar, Output = Self::Scalar> +
         Div<Self::Scalar, Output = Self::Scalar>;
-
+    
     fn lerp(self, other: Self, amount: Self::Scalar) -> Self;
 }
 
@@ -916,10 +916,10 @@ where
     T: Sub<T, Output = T>,
     T: Mul<T, Output = T>,
     T: Div<T, Output = T>,
-    // TODO: Remove this add assign bound. This is purely for ease of
+    // TODO: Remove this add assign bound. This is purely for ease of 
     // implementation.
     T: AddAssign<T>,
-    Self: Clone,
+    Self: Clone, 
 {
     fn dot(self, rhs: Self) -> T {
         let mut lhs = MaybeUninit::new(self);
@@ -938,8 +938,8 @@ where
 }
 
 /// An `N`-by-`M` Column Major matrix.
-///
-/// Matrices can be created from arrays of Vectors of any size and scalar type.
+/// 
+/// Matrices can be created from arrays of Vectors of any size and scalar type. 
 /// As with Vectors there are convenience constructor functions for square matrices
 /// of the most common sizes.
 ///
@@ -955,11 +955,11 @@ where
 ///                     6, 1, -4,
 ///                     2, 3, -2 );
 /// ```
-///
+/// 
 */
 /// All operations performed on matrices produce fixed-size outputs. For example,
-/// taking the `transpose` of a non-square matrix will produce a matrix with the
-/// width and height swapped:
+/// taking the `transpose` of a non-square matrix will produce a matrix with the 
+/// width and height swapped: 
 ///
 /*
 /// ```
@@ -1025,7 +1025,7 @@ pub fn mat3x3<T>(
 ) -> Mat3x3<T> {
     Matrix::<T, 3, 3>(
         [ Vector::<T, 3>([ x00, x10, x20, ]),
-          Vector::<T, 3>([ x01, x11, x21, ]),
+          Vector::<T, 3>([ x01, x11, x21, ]),  
           Vector::<T, 3>([ x02, x12, x22, ]),  ]
     )
 }
@@ -1039,7 +1039,7 @@ pub fn mat4x4<T>(
 ) -> Mat4x4<T> {
     Matrix::<T, 4, 4>(
         [ Vector::<T, 4>([ x00, x10, x20, x30 ]),
-          Vector::<T, 4>([ x01, x11, x21, x31 ]),
+          Vector::<T, 4>([ x01, x11, x21, x31 ]),  
           Vector::<T, 4>([ x02, x12, x22, x32 ]),
           Vector::<T, 4>([ x03, x13, x23, x33 ]) ]
     )
@@ -1160,7 +1160,7 @@ where
     }
 }
 
-/// I'm not quite sure how to format the debug output for a matrix.
+/// I'm not quite sure how to format the debug output for a matrix. 
 impl<T, const N: usize, const M: usize> fmt::Debug for Matrix<T, {N}, {M}>
 where
     T: fmt::Debug
@@ -1222,7 +1222,7 @@ where
         }
     }
 }
-
+    
 /// Element-wise subtraction of two equal sized matrices.
 impl<A, B, const N: usize, const M: usize> Sub<Matrix<B, {N}, {M}>> for Matrix<A, {N}, {M}>
 where
@@ -1392,7 +1392,7 @@ where
 }
 
 impl<T, const N: usize, const M: usize> Matrix<T, {N}, {M}> {
-    /// Returns the transpose of the matrix.
+    /// Returns the transpose of the matrix. 
     pub fn transpose(self) -> Matrix<T, {M}, {N}> {
         let mut from = MaybeUninit::new(self);
         let mut trans = MaybeUninit::<[Vector<T, {M}>; {N}]>::uninit();
@@ -1468,7 +1468,7 @@ where
         Vector::<Scalar, {N}>(unsafe { diag.assume_init() })
     }
 }
-
+    
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1503,7 +1503,7 @@ mod tests {
     /*
     #[test]
     fn test_vec_trunc() {
-
+        
         let (xyz, w): (TruncatedVector<_, 4>, _) = vec4(0u32, 1, 2, 3).trunc();
     }
     */
@@ -1563,7 +1563,7 @@ mod tests {
         let r = vec3(-3isize, 6isize, -3isize);
         assert_eq!(a.cross(b), r);
     }
-
+        
     #[test]
     fn test_vec_distance() {
         let a = Vector1::<f32>::from([ 0.0 ]);
@@ -1699,16 +1699,16 @@ mod tests {
 
     #[test]
     fn test_readme_code() {
-        let a = vec4( 0u32, 1, 2, 3 );
+        let a = vec4( 0u32, 1, 2, 3 ); 
         assert_eq!(
-	          a,
+	          a, 
             Vector::<u32, 4>::from([ 0u32, 1, 2, 3 ])
         );
 
         let b = Vector::<f32, 7>::from([ 0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, ]);
-        let c = Vector::<f32, 7>::from([ 1.0f32, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, ]) * 0.5;
+        let c = Vector::<f32, 7>::from([ 1.0f32, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, ]) * 0.5; 
         assert_eq!(
-            b + c,
+            b + c, 
             Vector::<f32, 7>::from([ 0.5f32, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5 ])
         );
 
@@ -1743,16 +1743,16 @@ mod tests {
                     0, 2, 0,
                     0, 0, 3 )
                 .diagonal(),
-            vec3( 1i32, 2, 3 )
+            vec3( 1i32, 2, 3 ) 
         );
 
         assert_eq!(
-            mat4x4( 1i32, 0, 0, 0,
-                    0, 2, 0, 0,
-                    0, 0, 3, 0,
+            mat4x4( 1i32, 0, 0, 0, 
+                    0, 2, 0, 0, 
+                    0, 0, 3, 0, 
                     0, 0, 0, 4 )
                 .diagonal(),
-            vec4( 1i32, 2, 3, 4 )
+            vec4( 1i32, 2, 3, 4 ) 
         );
     }
 


### PR DESCRIPTION
Adds swizzling support for up to the first 4 elements of a vector.

One thing that cgmath does that I haven't yet is put swizzling behind a feature flag. They claim that adding swizzling will add 0.6 MB to the library size, but then (correctly, AFAIK) point out that rustc will remove unused functions when building, so I'm not sure why they bothered with the flag. I didn't see a reason to, but I will add it if you want.