### PR TITLE
vector! and matrix!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,7 +1133,9 @@ impl<T, const N: usize, const M: usize> From<[Vector<T, {N}>; {M}]> for Matrix<T
 /// Construct a matrix of any size. The matrix is specified in row-major order,
 /// but this function converts it to aljabar's native column-major order.
 ///
-/// ```
+/// ```ignore
+/// # NOTE: This code fails to compile in a doc test, although it works fine in a
+/// # regular unit test.
 /// # use aljabar::*;
 /// // `matrix` allows you to create a matrix using natural writing order (row-major).
 /// let m1: Matrix<u32, 4, 3> = matrix([
@@ -1174,7 +1176,9 @@ pub fn matrix<T: Clone, const N: usize, const M: usize>(rows: [[T; M]; N]) -> Ma
 /// Construct a matrix of any size. The matrix is specified in row-major order,
 /// but this function converts it to aljabar's native column-major order.
 ///
-/// ```
+/// ```ignore
+/// # NOTE: This code fails to compile in a doc test, although it works fine in a
+/// # regular unit test.
 /// # use aljabar::*;
 /// // `matrix` allows you to create a matrix using natural writing order (row-major).
 /// let m1: Matrix<u32, 4, 3> = matrix![
@@ -2127,6 +2131,7 @@ mod tests {
             Vector::<u32, 3>::from([1, 3, 5]),
             Vector::<u32, 3>::from([2, 4, 6])
         ]));
+    }
 
     fn test_swizzle() {
         let v: Vector<f32, 1> = Vector::<f32, 1>::from([1.0]);

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -1,0 +1,16 @@
+extern crate aljabar;
+
+use aljabar::{matrix, vector};
+
+#[test]
+fn can_use_vector_macro_outside_aljabar() {
+    let _ = vector![1, 2, 3, 4, 5, 6];
+}
+
+#[test]
+fn can_use_matrix_macro_outside_aljabar() {
+    let _ = matrix![
+        [1, 2, 3],
+        [4, 5, 6],
+    ];
+}


### PR DESCRIPTION
Adds vector! and matrix! macros. Right now they only support explicit element listing, not repeat expressions. I'd like to support repeat expressions eventually but it was more work than I had time to do today.

Examples:
```rust
let v: Vector<f32, 3> = vector![1.0, 2.0, 3.0];
let m: Matrix<f32, 3, 2> = matrix![
    [1.0, 2.0],
    [3.0, 4.0],
    [5.0, 6.0]
];
```

They're implemented using procedural macros, so I needed to create a separate crate to hold the proc macros.