### PR TITLE
Add `indexed_map`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,6 +740,13 @@ impl<T, const N: usize> Vector<T, {N}> {
     where
         F: FnMut(T) -> Out,
     {
+        self.indexed_map(|_, x: T| -> Out { f(x) })
+    }
+
+    pub fn indexed_map<Out, F>(self, mut f: F) -> Vector<Out, {N}>
+    where
+        F: FnMut(usize, T) -> Out,
+    {
         let mut from = MaybeUninit::new(self);
         let mut to = MaybeUninit::<Vector<Out, {N}>>::uninit();
         let fromp: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut from) };
@@ -748,6 +755,7 @@ impl<T, const N: usize> Vector<T, {N}> {
             unsafe {
                 top.add(i).write(
                     f(
+                        i,
                         fromp
                             .add(i)
                             .replace(MaybeUninit::uninit())
@@ -3070,6 +3078,15 @@ mod tests {
             vec,
             vec![ 1i32, 2, 3, 4 ]
         )
+
+    #[test]
+    fn test_vec_indexed_map() {
+        let boolean = vector!(true, false, true, true, false, true, true, false, false, false);
+        let indices = vector!(0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assert_eq!(
+            boolean.indexed_map(|i, _| i),
+            indices
+        );
     }
 
     /*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3078,6 +3078,7 @@ mod tests {
             vec,
             vec![ 1i32, 2, 3, 4 ]
         )
+    }
 
     #[test]
     fn test_vec_indexed_map() {


### PR DESCRIPTION
Adds `indexed_map` to allow indexing operations when mapping.

Not sure how much ceremony is required here, but I think it makes a good addition. Let me know if there's something that I should add.