### PR TITLE
LU Decomposition Discussion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ required-features = ["serde"]
 
 [dev-dependencies]
 serde_json = "1.0"
+approx = "0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 
 #![feature(const_generics)]
 #![feature(trivial_bounds)]
-#![feature(specialization)]
 
 use core::{
     fmt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3138,7 +3138,7 @@ mod tests {
     #[test]
     fn test_vec_into_iter() {
         let v = vector!(1i32, 2, 3, 4);
-        let vec: Vec<_> = v.into_iter().collect();
+        let vec: Vec<i32> = v.into_iter().collect();
         assert_eq!(vec, vec![1i32, 2, 3, 4])
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3341,14 +3341,14 @@ mod tests {
         let rot = Orthonormal::<f32, 3>::from(Euler {
             x: 0.0,
             y: 0.0,
-            z: std::f32::consts::FRAC_PI_2,
+            z: core::f32::consts::FRAC_PI_2,
         });
         assert_eq!(rot.rotate_vector(vector![1.0f32, 0.0, 0.0]).y(), 1.0);
         let v = vector![1.0f32, 0.0, 0.0];
         let q1 = Quaternion::from(Euler {
             x: 0.0,
             y: 0.0,
-            z: std::f32::consts::FRAC_PI_2,
+            z: core::f32::consts::FRAC_PI_2,
         });
         assert_eq!(q1.rotate_vector(v).normalize().y(), 1.0);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! moment.
 //!
 
+#![allow(incomplete_features)]
 #![feature(const_generics)]
 #![feature(trivial_bounds)]
 #![feature(maybe_uninit_ref)]


### PR DESCRIPTION
I figured I'd create a draft pull request to gage the interest in adding LU decomposition and soliciting some feedback. An issue would perhaps be ideal for this purpose, but I had some example code with _breaking changes_.

The following code is a crude "rustification" of https://en.wikipedia.org/wiki/LU_decomposition#C_code_examples, and is intended as a proposal to build on (or scrap entirely!).

I put the `decompose` under `impl<T: Float, const N: usize> Matrix<T, {N}, {N}>`, even though it obviously belongs under `SquareMatrix`. This was done because I was unable to implement `invert` for every `SquareMatrix` given the current constraints. I am slightly confused by `SquareMatrix` and its existence, isn't a `SquareMatrix` simply a `Matrix<T, {N}, {N}>`?

I don't know what the ideal course of action is, or if this is at all aligns with your plans for the library. I am ready to put some more effort into this as soon as the following is answered.

1. Is there an interest in having LU-decomposition `aljabar`?
1. Is a transition to `num-traits` desirable? (I've had some issues with `num-traits` already, for example the `Float`-trait requiring `Copy`, rather than `Clone`, which is quite limiting.)