### PR TITLE
Minor fix to `invert`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2544,8 +2544,8 @@ where
             ])),
             2 => Matrix::<Scalar, { N }, { N }>::from_iter(SmallVec::from_buf([
                 self[(1, 1)].clone() / det.clone(),
-                -self[(0, 1)].clone() / det.clone(),
                 -self[(1, 0)].clone() / det.clone(),
+                -self[(0, 1)].clone() / det.clone(),
                 self[(0, 0)].clone() / det.clone(),
             ])),
             _ => unimplemented!(),
@@ -3254,7 +3254,7 @@ mod tests {
         let identity: Mat2x2<f64> = Mat2x2::<f64>::one();
         assert_eq!(
             a.invert().unwrap(),
-            matrix![[-2.0f64, 1.5f64], [1.0f64, -0.5f64]]
+            matrix![[-2.0f64, 1.0f64], [1.5f64, -0.5f64]]
         );
 
         assert_eq!(a.invert().unwrap() * a, identity);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2514,8 +2514,8 @@ where
             0 => <Scalar as One>::one(),
             1 => self[0][0].clone(),
             2 => {
-                (self[(0, 0)].clone() * self[(1, 1)].clone()
-                    - self[(1, 0)].clone() * self[(0, 1)].clone())
+                self[(0, 0)].clone() * self[(1, 1)].clone()
+                    - self[(1, 0)].clone() * self[(0, 1)].clone()
             }
             3 => {
                 let minor1 = self[(1, 1)].clone() * self[(2, 2)].clone()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,33 +473,38 @@ impl<T, const N: usize> FromIterator<T> for Vector<T, { N }> {
 
 /// Iterator over an array type.
 pub struct ArrayIter<T, const N: usize> {
-    array: MaybeUninit<[T; { N }]>,
+    array: [T; { N }],
     pos: usize,
 }
 
-impl<T, const N: usize> Iterator for ArrayIter<T, { N }> {
+impl<T, const N: usize> Iterator for ArrayIter<T, { N }>
+where
+    T: Clone,
+{
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos == N {
             None
         } else {
-            let pos = self.pos;
+            let old_pos = self.pos;
             self.pos += 1;
-            let arrayp: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut self.array) };
-            Some(unsafe { arrayp.add(pos).replace(MaybeUninit::uninit()).assume_init() })
+            Some(self.array[old_pos].clone())
         }
     }
 }
 
-impl<T, const N: usize> IntoIterator for Vector<T, { N }> {
+impl<T, const N: usize> IntoIterator for Vector<T, { N }>
+where
+    T: Clone,
+{
     type Item = T;
     type IntoIter = ArrayIter<T, { N }>;
 
     fn into_iter(self) -> Self::IntoIter {
         let Vector(array) = self;
         ArrayIter {
-            array: MaybeUninit::new(array),
+            array: array,
             pos: 0,
         }
     }
@@ -1435,14 +1440,17 @@ where
     }
 }
 
-impl<T, const N: usize> IntoIterator for Point<T, { N }> {
+impl<T, const N: usize> IntoIterator for Point<T, { N }>
+where
+    T: Clone,
+{
     type Item = T;
     type IntoIter = ArrayIter<T, { N }>;
 
     fn into_iter(self) -> Self::IntoIter {
         let Point(array) = self;
         ArrayIter {
-            array: MaybeUninit::new(array),
+            array: array,
             pos: 0,
         }
     }
@@ -1919,14 +1927,17 @@ impl<T, const N: usize, const M: usize> FromIterator<Vector<T, { N }>> for Matri
     }
 }
 
-impl<T, const N: usize, const M: usize> IntoIterator for Matrix<T, { N }, { M }> {
+impl<T, const N: usize, const M: usize> IntoIterator for Matrix<T, { N }, { M }>
+where
+    T: Clone,
+{
     type Item = Vector<T, { N }>;
     type IntoIter = ArrayIter<Vector<T, { N }>, { M }>;
 
     fn into_iter(self) -> Self::IntoIter {
         let Matrix(array) = self;
         ArrayIter {
-            array: MaybeUninit::new(array),
+            array: array,
             pos: 0,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2487,8 +2487,6 @@ where
     Self: Mul<Self>,
     Self: Mul<Vector<Scalar, { N }>, Output = Vector<Scalar, { N }>>,
 {
-    N}>, Output = Vector<Scalar, {N}>>,
-{
     /// Returns the [determinant](https://en.wikipedia.org/wiki/Determinant) of
     /// the Matrix.
     fn determinant(&self) -> Scalar;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3251,10 +3251,14 @@ mod tests {
         // Example taken from cgmath:
 
         let a: Mat2x2<f64> = matrix![[1.0f64, 2.0f64], [3.0f64, 4.0f64],];
+        let identity: Mat2x2<f64> = Mat2x2::<f64>::one();
         assert_eq!(
             a.invert().unwrap(),
             matrix![[-2.0f64, 1.5f64], [1.0f64, -0.5f64]]
         );
+
+        assert_eq!(a.invert().unwrap() * a, identity);
+        assert_eq!(a * a.invert().unwrap(), identity);
         assert!(matrix![[0.0f64, 2.0f64], [0.0f64, 5.0f64]]
             .invert()
             .is_none());

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -9,8 +9,5 @@ fn can_use_vector_macro_outside_aljabar() {
 
 #[test]
 fn can_use_matrix_macro_outside_aljabar() {
-    let _ = matrix![
-        [1, 2, 3],
-        [4, 5, 6],
-    ];
+    let _ = matrix![[1, 2, 3], [4, 5, 6],];
 }

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -1,37 +1,18 @@
- use aljabar::{Matrix, matrix, Vector, vector};
+use aljabar::{matrix, vector, Matrix, Vector};
 
 #[test]
 fn test_serialize() {
-    let v = vector![ 1u32, 2, 3, 4, 5, 6, 7 ];
-    assert_eq!(
-        serde_json::to_string(&v).unwrap(),
-        "[1,2,3,4,5,6,7]"
-    );
-    let m = matrix![
-        [ 1u32, 2 ],
-        [ 3u32, 4 ],
-    ];
-    assert_eq!(
-        serde_json::to_string(&m).unwrap(),
-        "[[1,3],[2,4]]"
-    );
+    let v = vector![1u32, 2, 3, 4, 5, 6, 7];
+    assert_eq!(serde_json::to_string(&v).unwrap(), "[1,2,3,4,5,6,7]");
+    let m = matrix![[1u32, 2], [3u32, 4],];
+    assert_eq!(serde_json::to_string(&m).unwrap(), "[[1,3],[2,4]]");
 }
 
 // Doesn't currently work due to a compiler bug.
 #[test]
 fn test_deserialize() {
     let v: Vector<u32, 7> = serde_json::from_str(&"[1,2,3,4,5,6,7]").unwrap();
-    assert_eq!(
-        v,
-        vector![ 1u32, 2, 3, 4, 5, 6, 7 ],
-    );
+    assert_eq!(v, vector![1u32, 2, 3, 4, 5, 6, 7],);
     let m: Matrix<u32, 2, 2> = serde_json::from_str(&"[[1,3],[2,4]]").unwrap();
-    assert_eq!(
-        m,
-        matrix![
-            [ 1u32, 2 ],
-            [ 3u32, 4 ],
-        ],
-    );
+    assert_eq!(m, matrix![[1u32, 2], [3u32, 4],],);
 }
-


### PR DESCRIPTION
My intent was for these to be backwards compatible, but I guess the `T: Clone` bound ruins that. Thoughts?