### PR TITLE
Index fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,8 +727,8 @@ mod tests {
 
     #[test]
     fn test_decompose() {
-        let a = matrix![[2.0, 1.0], [-1.0f64, 1.0]];
-        let b = vector!(2.0f64, 5.0);
+        let a = matrix![[-1.0f64, 1.0], [2.0, 1.0]];
+        let b = vector!(5.0f64, 2.0);
         let lu = a.lu().unwrap();
 
         assert_eq!(a * lu.solve(b), b);

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -933,7 +933,7 @@ impl<T, const N: usize> Index<(usize, usize)> for LU<T, { N }> {
     type Output = T;
 
     fn index(&self, (row, column): (usize, usize)) -> &Self::Output {
-        &self.1[(self.0[row], column)]
+        &self.1[(row, column)]
     }
 }
 


### PR DESCRIPTION
Now that `swap_rows(i, j)` swaps the rows of the matrix, we no
longer need to index via the permutation.

Discovered this through some https://github.com/BurntSushi/quickcheck exploration (https://github.com/maplant/aljabar/commit/3ffb2a15b1afb992718810b9d1ff6498e7d0e8ae), any interest in adding this?

Seems very suitable for testing various properties (i.e. going to town on https://en.wikipedia.org/wiki/Determinant#Properties_of_the_determinant).