### PR TITLE
Preliminary optimizing matrix swap

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -85,27 +85,13 @@ pub struct Matrix<T, const N: usize, const M: usize>(pub(crate) [Vector<T, { N }
 impl<T, const N: usize, const M: usize> Matrix<T, { N }, { M }> {
     /// Swap the two given columns in-place.
     pub fn swap_columns(&mut self, a: usize, b: usize) {
-        // Swapping when a == b is a no-op.
-        if a == b {
-            return;
-        }
-        let a: *mut MaybeUninit<Vector<T, { N }>> = unsafe { mem::transmute(&mut self.0[a]) };
-        let b: *mut MaybeUninit<Vector<T, { N }>> = unsafe { mem::transmute(&mut self.0[b]) };
-        // The following should return a MaybeUninit<T>, which will not be dropped.
-        unsafe { a.replace(b.replace(a.replace(MaybeUninit::uninit()))) };
+        unsafe { core::ptr::swap(&mut self.0[a], &mut self.0[b]) };
     }
 
     /// Swap the two given rows in-place.
     pub fn swap_rows(&mut self, a: usize, b: usize) {
-        // Swapping when a == b is a no-op.
-        if a == b {
-            return;
-        }
-        for i in 0..N {
-            let a: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut self.0[i][a]) };
-            let b: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut self.0[i][b]) };
-            // The following should return a MaybeUninit<T>, which will not be dropped.
-            unsafe { a.replace(b.replace(a.replace(MaybeUninit::uninit()))) };
+        for v in self.0.iter_mut() {
+            unsafe { core::ptr::swap(&mut v[a], &mut v[b]) };
         }
     }
 


### PR DESCRIPTION
The code have been shortened and written in a way i believe to be more optimal.

This change removes branching from the code. The for loop should not branch, since the size of the matrix is known at compile time.

The change comes with the added benefit of shorter and (subjectively) more readable code.