### PR TITLE
Add `const_evaluatable_checked` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@
 #![feature(const_generics)]
 #![feature(trivial_bounds)]
 #![feature(maybe_uninit_ref)]
+#![feature(maybe_uninit_uninit_array)]
 
 use core::{
     cmp::PartialOrd,
@@ -181,7 +182,7 @@ use core::{
     hash::{Hash, Hasher},
     iter::{FromIterator, Product},
     marker::PhantomData,
-    mem::{self, MaybeUninit},
+    mem::{self, transmute_copy, MaybeUninit},
     ops::{
         Add, AddAssign, Deref, DerefMut, Div, DivAssign, Index, IndexMut, Mul, MulAssign, Neg, Sub,
         SubAssign,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@
 //! ```
 
 #![allow(incomplete_features)]
+#![feature(const_evaluatable_checked)]
 #![feature(const_generics)]
 #![feature(trivial_bounds)]
 #![feature(maybe_uninit_ref)]

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -882,12 +882,12 @@ impl<const N: usize> DerefMut for Permutation<{ N }> {
 impl<const N: usize> Permutation<{ N }> {
     /// Returns the unit permutation.
     pub fn unit() -> Permutation<{ N }> {
-        let mut arr = MaybeUninit::<[usize; N]>::uninit();
+        let mut arr: [MaybeUninit<usize>; N] = MaybeUninit::uninit_array();
         let arr = unsafe {
             for i in 0..N {
-                *arr.get_mut().index_mut(i) = i;
+                arr[i] = MaybeUninit::new(i);
             }
-            arr.assume_init()
+            transmute_copy::<_, _>(&arr)
         };
         Permutation { arr, num_swaps: 0 }
     }


### PR DESCRIPTION
@lcnr has been a hero and fixed the `error: constant expression depends on a generic parameter` with `{Extended,Truncated}Vector`: https://github.com/rust-lang/rust/issues/68436#issuecomment-702622679

I had to make one additional alteration in order to make it compile on newest nightly (cargo 1.48.0-nightly (05c611ae3 2020-09-23)), not sure if it's ideal.

Resolves https://github.com/maplant/aljabar/issues/21.