### PR TITLE
Rename aljabar to al-jabr, reset version to 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "aljabar"
-version = "1.0.2"
+name = "al-jabr"
+version = "0.1.0"
 authors = ["Matthew Plant <map@maplant.com>", "Øystein Hovind <oystein.hovind@folq.no>"]
 edition = "2018"
-description = "A super generic, super experimental linear algebra library."
+description = "An n-dimensional linear algebra library intended for game development."
 license = "MIT/Apache-2.0"
 
-documentation = "https://docs.rs/crate/aljabar"
-homepage = "https://github.com/maplant/aljabar"
-repository = "https://github.com/maplant/aljabar"
+documentation = "https://docs.rs/crate/al-jabr"
+homepage = "https://github.com/maplant/al-jabr"
+repository = "https://github.com/maplant/al-jabr"
 readme = "README.md"
 
-keywords = [ "linear", "algebra", "matrix", "vector", "math" ]
+keywords = [ "linear", "algebra", "matrix", "vector", "math", "quaternion", "gamedev"]
 
 [lib]
-name = "aljabar"
+name = "al_jabr"
 
 [dependencies]
 mint = { version = "0.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# aljabar 
+# al-jabr 
 
-[![Build Status](https://api.travis-ci.org/maplant/aljabar.svg?branch=master)](https://travis-ci.org/github/maplant/aljabar)
-[![Documentation](https://docs.rs/aljabar/badge.svg)](https://docs.rs/aljabar)
-[![Version](https://img.shields.io/crates/v/aljabar.svg)](https://crates.io/crates/aljabar)
-[![Downloads](https://img.shields.io/crates/d/aljabar.svg)](https://crates.io/crates/aljabar)
+[![Build Status](https://api.travis-ci.org/maplant/al-jabr.svg?branch=master)](https://travis-ci.org/github/maplant/al-jabr)
+[![Documentation](https://docs.rs/al-jabr/badge.svg)](https://docs.rs/al-jabr)
+[![Version](https://img.shields.io/crates/v/al-jabr.svg)](https://crates.io/crates/al-jabr)
+[![Downloads](https://img.shields.io/crates/d/al-jabr.svg)](https://crates.io/crates/al-jabr)
 
-An experimental n-dimensional linear algebra and mathematics library for computer
+An n-dimensional linear algebra and mathematics library for computer
 graphics, designed to be roughly compatible with [cgmath](https://github.com/rustgd/cgmath).
 
 The library provides:
@@ -17,20 +17,17 @@ The library provides:
 * orthonormal (rotation) matrices: `Orthonormal`
 
 
-`aljabar` supports Vectors and Matrices of any size and will provide 
+`al-jabr` supports Vectors and Matrices of any size and will provide 
 implementations for any mathematic operations that are supported by their
-scalars. Additionally, aljabar can leverage Rust's type system to ensure that
-operations are only applied to values that are the correct size. `aljabar` can
+scalars. Additionally, al-jabr can leverage Rust's type system to ensure that
+operations are only applied to values that are the correct size. `al-jabr` can
 do this while remaining no-std compatible. 
 
-`aljabar` relies heavily on unstable Rust features such as const generics and thus
-requires nightly to build. 
-
-For more information and a guide on getting started, check out the [documentation](https://docs.rs/aljabar/).
+For more information and a guide on getting started, check out the [documentation](https://docs.rs/al-jabr/).
 
 ## Cargo Features
 
-* The `mint` feature (off by default) adds a dependency to the [mint](https://crates.io/crates/mint) crate and provides support for converting between aljabar types and mint types.
+* The `mint` feature (off by default) adds a dependency to the [mint](https://crates.io/crates/mint) crate and provides support for converting between al-jabr types and mint types.
 * The `serde` feature (off by default) adds serialization/deserialization support from the [serde](https://crates.io/crates/serde) crate.
 * The `rand` feature (off by default) allows you to create random points, vectors, and matrices by sampling from a random number source.
 * The `swizzle` feature (off by default) enables [swizzle](https://en.wikipedia.org/wiki/Swizzling_(computer_graphics)) functions for vectors.
@@ -38,11 +35,11 @@ For more information and a guide on getting started, check out the [documentatio
 ## Contributions
 
 Pull request of any nature are welcome, especially regaring performance improvements.
-Although a aljabar is generic with respect to dimensionality, algorithms specialized 
+Although a al-jabr is generic with respect to dimensionality, algorithms specialized 
 for certain dimensions are straightforward to add and are intended to replace the 
 generic algorithms along the most common code paths in the future.
 
 ## Support 
 
-Contact the author at `map@maplant.com` or [file an issue on github.](https://github.com/maplant/aljabar/issues/new/choose)
+Contact the author at `map@maplant.com` or [file an issue on github.](https://github.com/maplant/al-jabr/issues/new/choose)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The Aljabar Developers. For a full listing of authors,
+// Copyright 2019 The Al_Jabr Developers. For a full listing of authors,
 // refer to the Cargo.toml file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -7,26 +7,26 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
-//! The super generic super experimental linear algebra library.
+//! A generic linear algebra library for computer graphics.
 //!
-//! `aljabar` is roughly compatibly with [cgmath](https://github.com/rustgd/cgmath)
+//! `al_jabr` is roughly compatibly with [cgmath](https://github.com/rustgd/cgmath)
 //! and is intended to provide a small set of lightweight linear algebra
 //! operations typically useful in interactive computer graphics.
 //!
-//! `aljabar` is n-dimensional, meaning that its data structures support an
+//! `al_jabr` is n-dimensional, meaning that its data structures support an
 //! arbitrary number of elements. If you wish to create a five-dimensional rigid
-//! body simulation, `aljabar` can help you.
+//! body simulation, `al_jabr` can help you.
 //!
 //! ## Getting started
 //!
-//! All of `aljabar`'s types are exported in the root of the crate, so importing
+//! All of `al_jabr`'s types are exported in the root of the crate, so importing
 //! them all is as easy as adding the following to the top of your source file:
 //!
 //! ```
-//! use aljabar::*;
+//! use al_jabr::*;
 //! ```
 //!
-//! After that, you can begin using `aljabar`.
+//! After that, you can begin using `al_jabr`.
 //!
 //! ### Vector
 //!
@@ -34,7 +34,7 @@
 //! Use the [vector!] macro to easily construct a vector:
 //!
 //! ```
-//! # use aljabar::*;
+//! # use al_jabr::*;
 //! let a = vector![ 0u32, 1, 2, 3 ];
 //! assert_eq!(
 //!     a,
@@ -47,7 +47,7 @@
 //! Operations are only implemented for vectors of equal sizes.
 //!
 //! ```
-//! # use aljabar::*;
+//! # use al_jabr::*;
 //! let b = vector![ 0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, ];
 //! let c = vector![ 1.0f32, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, ] * 0.5;
 //! assert_eq!(
@@ -64,7 +64,7 @@
 //! the magnitude of a vector can be found in addition:
 //!
 //! ```rust
-//! # use aljabar::*;
+//! # use al_jabr::*;
 //! let a = vector!(1i32, 1);
 //! let b = vector!(5i32, 5);
 //! assert_eq!(a.distance2(b), 32);       // distance method not implemented.
@@ -91,8 +91,8 @@
 //! raw array reflects that. The [matrix!] macro can be used to construct a
 //! matrix in row-major order:
 //!
-//! ```ignore
-//! # use aljabar::*;
+//! ```
+//! # use al_jabr::*;
 //! let a = Matrix::<f32, 3, 3>::from([
 //!     vector!(1.0, 0.0, 0.0),
 //!     vector!(0.0, 1.0, 0.0),
@@ -110,8 +110,8 @@
 //! example, taking the [transpose](Matrix::transpose) of a non-square matrix
 //! will produce a matrix with the width and height swapped:
 //!
-//! ```ignore
-//! # use aljabar::*;
+//! ```
+//! # use al_jabr::*;
 //! assert_eq!(
 //!     Matrix::<i32, 1, 2>::from([ vector!( 1 ), vector!(2) ])
 //!         .transpose(),
@@ -124,7 +124,7 @@
 //! matrices of equal size:
 //!
 //! ```
-//! # use aljabar::*;
+//! # use al_jabr::*;
 //! let a = matrix!(1_u32);
 //! let b = matrix!(2_u32);
 //! let c = matrix!(3_u32);
@@ -135,7 +135,7 @@
 //! following is possible as well:
 //!
 //! ```
-//! # use aljabar::*;
+//! # use al_jabr::*;
 //! let a = matrix!(matrix!(1_u32));
 //! let b = matrix!(matrix!(2_u32));
 //! let c = matrix!(matrix!(3_u32));
@@ -147,7 +147,7 @@
 //! result is a `Matrix<T, N, P>`:
 //!
 //! ```rust
-//! # use aljabar::*;
+//! # use al_jabr::*;
 //! let a: Matrix::<i32, 3, 3> = matrix![
 //!     [ 0, -3, 5 ],
 //!     [ 6, 1, -4 ],
@@ -169,11 +169,6 @@
 //! );
 //! ```
 
-#![allow(incomplete_features)]
-#![feature(const_evaluatable_checked)]
-#![feature(const_generics)]
-#![feature(trivial_bounds)]
-#![feature(maybe_uninit_ref)]
 #![feature(maybe_uninit_uninit_array)]
 
 use core::{
@@ -599,7 +594,7 @@ mod tests {
     }
 
     #[test]
-    fn test_permutation_parity() {
+    fn permutation_parity() {
         let p1 = Permutation::<4>::unit();
         let p2 = Permutation([3usize, 1, 2, 0]);
         let p3 = Permutation([2usize, 3, 1, 0]);
@@ -610,13 +605,13 @@ mod tests {
     */
 
     #[test]
-    fn test_vec_zero() {
+    fn vec_zero() {
         let a = Vector3::<u32>::zero();
         assert_eq!(a, Vector3::<u32>::from([0, 0, 0]));
     }
 
     #[test]
-    fn test_vec_index() {
+    fn vec_index() {
         let a = Vector1::<u32>::from([0]);
         assert_eq!(a[0], 0);
         let mut b = Vector2::<u32>::from([1, 2]);
@@ -625,7 +620,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_eq() {
+    fn vec_eq() {
         let a = Vector1::<u32>::from([0]);
         let b = Vector1::<u32>::from([1]);
         let c = Vector1::<u32>::from([0]);
@@ -637,7 +632,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_addition() {
+    fn vec_addition() {
         let a = Vector1::<u32>::from([0]);
         let b = Vector1::<u32>::from([1]);
         let c = Vector1::<u32>::from([2]);
@@ -659,7 +654,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_subtraction() {
+    fn vec_subtraction() {
         let mut a = Vector1::<u32>::from([3]);
         let b = Vector1::<u32>::from([1]);
         let c = Vector1::<u32>::from([2]);
@@ -669,14 +664,14 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_negation() {
+    fn vec_negation() {
         let a = Vector4::<i32>::from([1, 2, 3, 4]);
         let b = Vector4::<i32>::from([-1, -2, -3, -4]);
         assert_eq!(-a, b);
     }
 
     #[test]
-    fn test_vec_scale() {
+    fn vec_scale() {
         let a = Vector4::<f32>::from([2.0, 4.0, 2.0, 4.0]);
         let b = Vector4::<f32>::from([4.0, 8.0, 4.0, 8.0]);
         let c = Vector4::<f32>::from([1.0, 2.0, 1.0, 2.0]);
@@ -685,7 +680,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_cross() {
+    fn vec_cross() {
         let a = vector!(1isize, 2isize, 3isize);
         let b = vector!(4isize, 5isize, 6isize);
         let r = vector!(-3isize, 6isize, -3isize);
@@ -693,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_distance() {
+    fn vec_distance() {
         let a = Vector1::<f32>::from([0.0]);
         let b = Vector1::<f32>::from([1.0]);
         assert_eq!(a.distance2(b), 1.0);
@@ -707,7 +702,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_normalize() {
+    fn vec_normalize() {
         let a = vector!(5.0);
         assert_eq!(a.clone().magnitude(), 5.0);
         let a_norm = a.normalize();
@@ -715,20 +710,20 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_transpose() {
+    fn vec_transpose() {
         let v = vector!(1i32, 2, 3, 4);
         let m = Matrix::<i32, 1, 4>::from([vector!(1i32), vector!(2), vector!(3), vector!(4)]);
         assert_eq!(v.transpose(), m);
     }
 
     #[test]
-    fn test_from_fn() {
+    fn from_fn() {
         let indices: Vector<usize, 10> = vector!(0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         assert_eq!(Vector::<usize, 10>::from_fn(|i| i), indices);
     }
 
     #[test]
-    fn test_decompose() {
+    fn decompose() {
         let a = matrix![[-1.0f64, 1.0], [2.0, 1.0]];
         let b = vector!(5.0f64, 2.0);
         let lu = a.lu().unwrap();
@@ -737,28 +732,28 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_map() {
+    fn vec_map() {
         let int = vector!(1i32, 0, 1, 1, 0, 1, 1, 0, 0, 0);
         let boolean = vector!(true, false, true, true, false, true, true, false, false, false);
         assert_eq!(int.map(|i| i != 0), boolean);
     }
 
     #[test]
-    fn test_vec_from_iter() {
+    fn vec_from_iter() {
         let v = vec![1i32, 2, 3, 4];
         let vec = Vector::<i32, 4>::from_iter(v);
         assert_eq!(vec, vector![1i32, 2, 3, 4])
     }
 
     #[test]
-    fn test_vec_into_iter() {
+    fn vec_into_iter() {
         let v = vector!(1i32, 2, 3, 4);
         let vec: Vec<i32> = v.into_iter().collect();
         assert_eq!(vec, vec![1i32, 2, 3, 4])
     }
 
     #[test]
-    fn test_vec_indexed_map() {
+    fn vec_indexed_map() {
         let boolean = vector!(true, false, true, true, false, true, true, false, false, false);
         let indices = vector!(0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         assert_eq!(boolean.indexed_map(|i, _| i), indices);
@@ -767,7 +762,7 @@ mod tests {
     // Does not compile.
     /*
     #[test]
-    fn test_vec_first() {
+    fn vec_first() {
         let a = Vector2::<i32>::from([ 1, 2 ]);
         let b = Vector3::<i32>::from([ 1, 2, 3 ]);
         let c = b.first::<2_usize>();
@@ -776,13 +771,13 @@ mod tests {
     */
 
     #[test]
-    fn test_mat_identity() {
+    fn mat_identity() {
         let unit = matrix![[1u32, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1],];
         assert_eq!(Matrix::<u32, 4, 4>::one(), unit);
     }
 
     #[test]
-    fn test_mat_negation() {
+    fn mat_negation() {
         let neg_unit = matrix![
             [-1i32, 0, 0, 0],
             [0, -1, 0, 0],
@@ -793,7 +788,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_add() {
+    fn mat_add() {
         let a = matrix![matrix![1u32]];
         let b = matrix![matrix![10u32]];
         let c = matrix![matrix![11u32]];
@@ -801,14 +796,14 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_scalar_mult() {
+    fn mat_scalar_mult() {
         let a = Matrix::<f32, 2, 2>::from([vector!(0.0, 1.0), vector!(0.0, 2.0)]);
         let b = Matrix::<f32, 2, 2>::from([vector!(0.0, 2.0), vector!(0.0, 4.0)]);
         assert_eq!(a * 2.0, b);
     }
 
     #[test]
-    fn test_mat_mult() {
+    fn mat_mult() {
         let a = Matrix::<f32, 2, 2>::from([vector!(0.0, 0.0), vector!(1.0, 0.0)]);
         let b = Matrix::<f32, 2, 2>::from([vector!(0.0, 1.0), vector!(0.0, 0.0)]);
         assert_eq!(a * b, matrix![[1.0, 0.0], [0.0, 0.0],]);
@@ -839,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_index() {
+    fn mat_index() {
         let m: Matrix<i32, 2, 2> = matrix![[0, 2], [1, 3],];
         assert_eq!(m[(0, 0)], 0);
         assert_eq!(m[0][0], 0);
@@ -852,7 +847,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_transpose() {
+    fn mat_transpose() {
         assert_eq!(
             Matrix::<i32, 1, 2>::from([vector!(1), vector!(2)]).transpose(),
             Matrix::<i32, 2, 1>::from([vector!(1, 2)])
@@ -864,14 +859,14 @@ mod tests {
     }
 
     #[test]
-    fn test_square_matrix() {
+    fn square_matrix() {
         let a: Matrix<i32, 3, 3> = matrix![[5, 0, 0], [0, 8, 12], [0, 0, 16],];
         let diag: Vector<i32, 3> = vector!(5, 8, 16);
         assert_eq!(a.diagonal(), diag);
     }
 
     #[test]
-    fn test_readme_code() {
+    fn readme_code() {
         let a = vector!(0u32, 1, 2, 3);
         assert_eq!(a, Vector::<u32, 4>::from([0u32, 1, 2, 3]));
 
@@ -918,7 +913,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_map() {
+    fn mat_map() {
         let int = matrix![[1i32, 0], [1, 1], [0, 1], [1, 0], [0, 0]];
         let boolean = matrix![
             [true, false],
@@ -931,14 +926,14 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_from_iter() {
+    fn mat_from_iter() {
         let v = vec![1i32, 2, 3, 4];
         let mat = Matrix::<i32, 2, 2>::from_iter(v);
         assert_eq!(mat, matrix![[1i32, 2], [3, 4]].transpose())
     }
 
     #[test]
-    fn test_mat_invert() {
+    fn mat_invert() {
         assert!(Matrix2::<f64>::one().invert().unwrap() == Matrix2::<f64>::one());
 
         // Example taken from cgmath:
@@ -958,7 +953,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_determinant() {
+    fn mat_determinant() {
         assert_eq!(Matrix2::<f64>::one().determinant(), f64::one());
         /*
         assert_eq!(
@@ -981,7 +976,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_swap() {
+    fn mat_swap() {
         let mut m = matrix![ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ];
         m.swap_columns(0, 1);
         assert_eq!(
@@ -1008,7 +1003,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_macro_constructor() {
+    fn vec_macro_constructor() {
         let v: Vector<f32, 0> = vector![];
         assert!(v.is_empty());
 
@@ -1022,7 +1017,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mat_macro_constructor() {
+    fn mat_macro_constructor() {
         let m: Matrix<f32, 0, 0> = matrix![];
         assert!(m.is_empty());
 
@@ -1040,7 +1035,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_swizzle() {
+    fn vec_swizzle() {
         let v: Vector<f32, 1> = Vector::<f32, 1>::from([1.0]);
         assert_eq!(1.0, v.x());
 
@@ -1067,7 +1062,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_reflect() {
+    fn vec_reflect() {
         // Incident straight on to the surface.
         let v = vector!(1, 0);
         let n = vector!(-1, 0);
@@ -1082,7 +1077,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rotation() {
+    fn rotation() {
         let rot = Orthonormal::<f32, 3>::from(Euler {
             x: 0.0,
             y: 0.0,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -7,8 +7,8 @@ use super::*;
 /// As with Vectors there are convenience constructor functions for square
 /// matrices of the most common sizes.
 ///
-/// ```ignore
-/// # use aljabar::*;
+/// ```
+/// # use al_jabr::*;
 /// let a = Matrix::<f32, 3, 3>::from( [ vector!( 1.0, 0.0, 0.0 ),
 ///                                      vector!( 0.0, 1.0, 0.0 ),
 ///                                      vector!( 0.0, 0.0, 1.0 ), ] );
@@ -23,8 +23,8 @@ use super::*;
 /// example, taking the `transpose` of a non-square matrix will produce a matrix
 /// with the width and height swapped:
 ///
-/// ```ignore
-/// # use aljabar::*;
+/// ```
+/// # use al_jabr::*;
 /// assert_eq!(
 ///     Matrix::<i32, 1, 2>::from( [ vector!( 1 ), vector!( 2 ) ] )
 ///         .transpose(),
@@ -41,7 +41,7 @@ use super::*;
 /// appropriate column of the matrix.
 ///
 /// ```
-/// # use aljabar::*;
+/// # use al_jabr::*;
 /// let m: Matrix::<i32, 2, 2> = matrix![
 ///     [ 0, 2 ],
 ///     [ 1, 3 ],
@@ -335,10 +335,10 @@ pub fn new_matrix<T: Clone, const N: usize, const M: usize>(
 }
 
 /// Construct a [Matrix] of any size. The matrix is specified in row-major
-/// order, but this function converts it to aljabar's native column-major order.
+/// order, but this function converts it to al_jabr's native column-major order.
 ///
-/// ```ignore
-/// # use aljabar::*;
+/// ```
+/// # use al_jabr::*;
 /// // `matrix` allows you to create a matrix using natural writing order (row-major).
 /// let m1: Matrix<u32, 4, 3> = matrix![
 ///     [0, 1, 2],
@@ -1117,9 +1117,9 @@ into_mint_row_matrix!(RowMatrix4x3, 4, 3, (x, 0), (y, 1), (z, 2), (w, 3));
 
 // It would be possible to implement this without a runtime transpose() by
 // directly copying the corresponding elements from the mint matrix to the
-// appropriate position in the aljabar matrix, but it would be substantially
+// appropriate position in the al_jabr matrix, but it would be substantially
 // more code to do so. I'm leaving it as a transpose for now in the expectation
-// that converting between aljabar and mint entities will occur infrequently at
+// that converting between al_jabr and mint entities will occur infrequently at
 // program boundaries.
 macro_rules! from_mint_row_matrix {
     ($mint_name:ident, $rows:expr, $cols:expr, $($component:ident),+) => {

--- a/src/point.rs
+++ b/src/point.rs
@@ -98,7 +98,7 @@ pub fn new_point<T, const N: usize>(elements: [T; N]) -> Point<T, { N }> {
 /// Construct a new [Point] of any size.
 ///
 /// ```
-/// # use aljabar::*;
+/// # use al_jabr::*;
 /// let p: Point<u32, 0> = point![];
 /// let p = point![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 /// let p = point![true, false, false, true];

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -7,7 +7,7 @@ use super::*;
 /// convenience constructor functions provided for the most common sizes.
 ///
 /// ```
-/// # use aljabar::*;
+/// # use al_jabr::*;
 /// let a: Vector::<u32, 4> = vector!( 0u32, 1, 2, 3 );
 /// assert_eq!(
 ///     a,
@@ -45,13 +45,13 @@ For example, `vec2(1i32, 2).z()` will panic because `z()` is only available on v
 of length 3 or greater. Previously, this was a compilation error. However, for newer
 versions of rustc this is no longer always the case.
 ```should_panic
-# use aljabar::*;
+# use al_jabr::*;
 let z = vector!(1i32, 2).z(); // Will panic.
 ```
 ### Mixing
 zle methods are not implemented for mixed xyzw/rgba methods.
 ```
-# use aljabar::*;
+# use al_jabr::*;
 let v = vector!(1i32, 2, 3, 4);
 let xy = v.xy(); // OK, only uses xyzw names.
 let ba = v.ba(); // OK, only uses rgba names.
@@ -59,30 +59,30 @@ assert_eq!(xy, vector!(1i32, 2));
 assert_eq!(ba, vector!(3i32, 4));
 ```
 ```compile_fail
-# use aljabar::*;
+# use al_jabr::*;
 let v = vector!(1i32, 2, 3, 4);
 let bad = v.xyrg(); // Compile error, mixes xyzw and rgba names.
 ```
 ## Examples
 To get the first two elements of a 4-vector.
 ```
-# use aljabar::*;
+# use al_jabr::*;
 let v = vector!(1i32, 2, 3, 4).xy();
 ```
 To get the first and last element of a 4-vector.
 ```
-# use aljabar::*;
+# use al_jabr::*;
 let v = vector!(1i32, 2, 3, 4).xw();
 ```
 To reverse the order of a 3-vector.
 ```
-# use aljabar::*;
+# use al_jabr::*;
 let v = vector!(1i32, 2, 3).zyx();
 ```
 To select the first and third elements into the second and fourth elements,
 respectively.
 ```
-# use aljabar::*;
+# use al_jabr::*;
 let v = vector!(1i32, 2, 3, 4).xxzz();
 ```
 "##
@@ -134,8 +134,8 @@ impl<T, const N: usize> Vector<T, { N }> {
 
     /// Converts the Vector into a Matrix with `N` columns each of size `1`.
     ///
-    /// ```ignore
-    /// # use aljabar::*;
+    /// ```
+    /// # use al_jabr::*;
     /// let v = vector!(1i32, 2, 3, 4);
     /// let m = Matrix::<i32, 1, 4>::from([
     ///     vector!(1i32),
@@ -161,11 +161,12 @@ impl<T, const N: usize> Vector<T, { N }> {
         unsafe { st.assume_init() }
     }
 
+    /*
     /// Removes the last component and returns the vector with one fewer
     /// dimension.
     ///
     /// ```
-    /// # use aljabar::*;
+    /// # use al_jabr::*;
     /// let (xyz, w) = vector!(0u32, 1, 2, 3).truncate();
     /// assert_eq!(xyz, vector!(0u32, 1, 2));
     /// assert_eq!(w, 3);
@@ -189,12 +190,14 @@ impl<T, const N: usize> Vector<T, { N }> {
                 .assume_init()
         })
     }
+    */
 
+    /*
     /// Extends the vector with an additional value.
     ///
     /// Useful for performing affine transformations.
     /// ```
-    /// # use aljabar::*;
+    /// # use al_jabr::*;
     /// let xyzw = vector!(0u32, 1, 2).extend(3);
     /// assert_eq!(xyzw, vector!(0u32, 1, 2, 3));
     /// ```
@@ -215,8 +218,10 @@ impl<T, const N: usize> Vector<T, { N }> {
             head.assume_init()
         }
     }
+    */
 }
 
+/*
 /// A `Vector` with one fewer dimension than `N`.
 ///
 /// Not particularly useful other than as the return value of the
@@ -230,6 +235,7 @@ pub type TruncatedVector<T, const N: usize> = Vector<T, { N - 1 }>;
 /// [extend](Vector::extend) method.
 #[doc(hidden)]
 pub type ExtendedVector<T, const N: usize> = Vector<T, { N + 1 }>;
+*/
 
 impl<T, const N: usize> Vector<T, { N }>
 where
@@ -376,7 +382,7 @@ pub fn new_vector<T, const N: usize>(elements: [T; N]) -> Vector<T, { N }> {
 /// Construct a new [Vector] of any size.
 ///
 /// ```
-/// # use aljabar::*;
+/// # use al_jabr::*;
 /// let v: Vector<u32, 0> = vector![];
 /// let v = vector![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 /// let v = vector![true, false, false, true];

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -1,13 +1,13 @@
-extern crate aljabar;
+extern crate al_jabr;
 
-use aljabar::{matrix, vector};
+use al_jabr::{matrix, vector};
 
 #[test]
-fn can_use_vector_macro_outside_aljabar() {
+fn can_use_vector_macro_outside_al_jabr() {
     let _ = vector![1, 2, 3, 4, 5, 6];
 }
 
 #[test]
-fn can_use_matrix_macro_outside_aljabar() {
+fn can_use_matrix_macro_outside_al_jabr() {
     let _ = matrix![[1, 2, 3], [4, 5, 6],];
 }


### PR DESCRIPTION
This version of the crate will be published to crates.io when the mvp const generic feature is enabled in stable rust.