### PR TITLE
Convert Vectors to be defined in terms of Matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project adheres to [Semantic Versioning](http://semver.org/) as of version 
 ## Unreleased Changes
 These changes are included in `master` but have not been released in a new crate version yet.
 
+## [v0.2.0]
+
+- Redefine Vector in terms of Matrices, as opposed to definining Matrices in terms of Vectors.
+  This is a more natural definition and allows for a dramatic reduction of code.
+
+## [v0.1.0] 
+
+- Renamed the crate to `al-jabr` and remove methods that are not compatible with rust stable.
+
 ## [v1.0.2] - 2020-10-26
 
 - Add `const_evaluatable_checked` unstable feature to allow for `truncate` and `extend` methods to be used.
@@ -35,7 +44,7 @@ These changes are included in `master` but have not been released in a new crate
 ## [v0.4.2] - 2019-12-07
 
 - Add support for the `mint` crate.
-- Add `IntoIterato` implementations for `Vector`, `Matrix` and `Point`.
+- Add `IntoIterator` implementations for `Vector`, `Matrix` and `Point`.
 
 ## [v0.4.1] - 2019-09-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ mint = { version = "0.5", optional = true }
 paste = "0.1"
 rand = { version = "0.7", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
+approx = { version = "0.4", optional = true }
 smallvec = "0.6"
 
 [features]
@@ -34,7 +35,7 @@ required-features = ["serde"]
 
 [dev-dependencies]
 serde_json = "1.0"
-approx = "0.3.2"
+approx = "0.4"
 
 [package.metadata.docs.rs]
 # No need ot clutter docs.rs with the mint converters.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,9 @@
 //! ```
 //! # use al_jabr::*;
 //! let a = Matrix::<f32, 3, 3>::from([
-//!     vector!(1.0, 0.0, 0.0),
-//!     vector!(0.0, 1.0, 0.0),
-//!     vector!(0.0, 0.0, 1.0),
+//!     [1.0, 0.0, 0.0],
+//!     [0.0, 1.0, 0.0],
+//!     [0.0, 0.0, 1.0],
 //! ]);
 //!
 //! let b: Matrix::<i32, 3, 3> = matrix![
@@ -113,9 +113,9 @@
 //! ```
 //! # use al_jabr::*;
 //! assert_eq!(
-//!     Matrix::<i32, 1, 2>::from([ vector!( 1 ), vector!(2) ])
+//!     Matrix::<i32, 1, 2>::from([ [ 1 ], [ 2 ] ])
 //!         .transpose(),
-//!     Matrix::<i32, 2, 1>::from([ vector!( 1, 2 ) ])
+//!     Matrix::<i32, 2, 1>::from([ [ 1, 2 ] ])
 //! );
 //! ```
 //!
@@ -125,9 +125,9 @@
 //!
 //! ```
 //! # use al_jabr::*;
-//! let a = matrix!(1_u32);
-//! let b = matrix!(2_u32);
-//! let c = matrix!(3_u32);
+//! let a = matrix!([1_u32]);
+//! let b = matrix!([2_u32]);
+//! let c = matrix!([3_u32]);
 //! assert_eq!(a + b, c);
 //! ```
 //!
@@ -136,9 +136,9 @@
 //!
 //! ```
 //! # use al_jabr::*;
-//! let a = matrix!(matrix!(1_u32));
-//! let b = matrix!(matrix!(2_u32));
-//! let c = matrix!(matrix!(3_u32));
+//! let a = matrix!([matrix!([1_u32])]);
+//! let b = matrix!([matrix!([2_u32])]);
+//! let c = matrix!([matrix!([3_u32])]);
 //! assert_eq!(a + b, c);
 //! ```
 //!
@@ -542,41 +542,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approx::{abs_diff_eq, AbsDiffEq};
-
-    impl<T: AbsDiffEq, const N: usize> AbsDiffEq for Vector<T, { N }>
-    where
-        T::Epsilon: Copy,
-    {
-        type Epsilon = T::Epsilon;
-
-        fn default_epsilon() -> T::Epsilon {
-            T::default_epsilon()
-        }
-
-        fn abs_diff_eq(&self, other: &Self, epsilon: T::Epsilon) -> bool {
-            self.iter()
-                .zip(other.iter())
-                .all(|(x, y)| T::abs_diff_eq(x, y, epsilon))
-        }
-    }
-
-    impl<T: AbsDiffEq, const N: usize, const M: usize> AbsDiffEq for Matrix<T, { N }, { M }>
-    where
-        T::Epsilon: Copy,
-    {
-        type Epsilon = T::Epsilon;
-
-        fn default_epsilon() -> T::Epsilon {
-            T::default_epsilon()
-        }
-
-        fn abs_diff_eq(&self, other: &Self, epsilon: T::Epsilon) -> bool {
-            self.column_iter()
-                .zip(other.column_iter())
-                .all(|(x, y)| Vector::<T, { N }>::abs_diff_eq(x, y, epsilon))
-        }
-    }
+    use approx::abs_diff_eq;
 
     type Vector1<T> = Vector<T, 1>;
 
@@ -605,16 +571,16 @@ mod tests {
     #[test]
     fn vec_zero() {
         let a = Vector3::<u32>::zero();
-        assert_eq!(a, Vector3::<u32>::from([0, 0, 0]));
+        assert_eq!(a, vector![0, 0, 0]);
     }
 
     #[test]
     fn vec_index() {
         let a = Vector1::<u32>::from([0]);
-        assert_eq!(a[0], 0);
+        assert_eq!(*a.x(), 0_u32);
         let mut b = Vector2::<u32>::from([1, 2]);
-        b[1] += 3;
-        assert_eq!(b[1], 5);
+        *b.y_mut() += 3;
+        assert_eq!(*b.y(), 5);
     }
 
     #[test]
@@ -622,11 +588,10 @@ mod tests {
         let a = Vector1::<u32>::from([0]);
         let b = Vector1::<u32>::from([1]);
         let c = Vector1::<u32>::from([0]);
-        let d = [0u32];
+        let d = [[0u32]];
         assert_ne!(a, b);
         assert_eq!(a, c);
-        assert_eq!(a, &d); // No blanket impl on T for deref... why? infinite
-                           // loops?
+        assert_eq!(a, &d);
     }
 
     #[test]
@@ -710,7 +675,7 @@ mod tests {
     #[test]
     fn vec_transpose() {
         let v = vector!(1i32, 2, 3, 4);
-        let m = Matrix::<i32, 1, 4>::from([vector!(1i32), vector!(2), vector!(3), vector!(4)]);
+        let m = Matrix::<i32, 1, 4>::from([[1i32], [2], [3], [4]]);
         assert_eq!(v.transpose(), m);
     }
 
@@ -743,12 +708,14 @@ mod tests {
         assert_eq!(vec, vector![1i32, 2, 3, 4])
     }
 
+    /*
     #[test]
     fn vec_into_iter() {
         let v = vector!(1i32, 2, 3, 4);
-        let vec: Vec<i32> = v.into_iter().collect();
+        let vec: Vec<_> = v.into_iter().collect();
         assert_eq!(vec, vec![1i32, 2, 3, 4])
     }
+    */
 
     #[test]
     fn vec_indexed_map() {
@@ -787,36 +754,36 @@ mod tests {
 
     #[test]
     fn mat_add() {
-        let a = matrix![matrix![1u32]];
-        let b = matrix![matrix![10u32]];
-        let c = matrix![matrix![11u32]];
+        let a = matrix![[matrix![[1u32]]]];
+        let b = matrix![[matrix![[10u32]]]];
+        let c = matrix![[matrix![[11u32]]]];
         assert_eq!(a + b, c);
     }
 
     #[test]
     fn mat_scalar_mult() {
-        let a = Matrix::<f32, 2, 2>::from([vector!(0.0, 1.0), vector!(0.0, 2.0)]);
-        let b = Matrix::<f32, 2, 2>::from([vector!(0.0, 2.0), vector!(0.0, 4.0)]);
+        let a = Matrix::<f32, 2, 2>::from([[0.0, 1.0], [0.0, 2.0]]);
+        let b = Matrix::<f32, 2, 2>::from([[0.0, 2.0], [0.0, 4.0]]);
         assert_eq!(a * 2.0, b);
     }
 
     #[test]
     fn mat_mult() {
-        let a = Matrix::<f32, 2, 2>::from([vector!(0.0, 0.0), vector!(1.0, 0.0)]);
-        let b = Matrix::<f32, 2, 2>::from([vector!(0.0, 1.0), vector!(0.0, 0.0)]);
+        let a = Matrix::<f32, 2, 2>::from([[0.0, 0.0], [1.0, 0.0]]);
+        let b = Matrix::<f32, 2, 2>::from([[0.0, 1.0], [0.0, 0.0]]);
         assert_eq!(a * b, matrix![[1.0, 0.0], [0.0, 0.0],]);
         assert_eq!(b * a, matrix![[0.0, 0.0], [0.0, 1.0],]);
         // Basic example:
-        let a: Matrix<usize, 1, 1> = matrix![1];
-        let b: Matrix<usize, 1, 1> = matrix![2];
-        let c: Matrix<usize, 1, 1> = matrix![2];
+        let a: Matrix<usize, 1, 1> = matrix![[1]];
+        let b: Matrix<usize, 1, 1> = matrix![[2]];
+        let c: Matrix<usize, 1, 1> = matrix![[2]];
         assert_eq!(a * b, c);
         // Removing the type signature here caused the compiler to crash.
         // Since then I've been wary.
         let a = Matrix::<f32, 3, 3>::from([
-            vector!(1.0, 0.0, 0.0),
-            vector!(0.0, 1.0, 0.0),
-            vector!(0.0, 0.0, 1.0),
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
         ]);
         let b = a.clone();
         let c = a * b;
@@ -847,8 +814,8 @@ mod tests {
     #[test]
     fn mat_transpose() {
         assert_eq!(
-            Matrix::<i32, 1, 2>::from([vector!(1), vector!(2)]).transpose(),
-            Matrix::<i32, 2, 1>::from([vector!(1, 2)])
+            Matrix::<i32, 1, 2>::from([[1], [2]]).transpose(),
+            Matrix::<i32, 2, 1>::from([[1, 2]])
         );
         assert_eq!(
             matrix![[1, 2], [3, 4],].transpose(),
@@ -893,9 +860,9 @@ mod tests {
         );
 
         let _a = Matrix::<f32, 3, 3>::from([
-            vector!(1.0, 0.0, 0.0),
-            vector!(0.0, 1.0, 0.0),
-            vector!(0.0, 0.0, 1.0),
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
         ]);
         let _b: Matrix<i32, 3, 3> = matrix![[0, -3, 5], [6, 1, -4], [2, 3, -2]];
 
@@ -938,13 +905,13 @@ mod tests {
 
         let a: Matrix2<f64> = matrix![[1.0f64, 2.0f64], [3.0f64, 4.0f64],];
         let identity: Matrix2<f64> = Matrix2::<f64>::one();
-        abs_diff_eq!(
+        assert!(abs_diff_eq!(
             a.invert().unwrap(),
             matrix![[-2.0f64, 1.0f64], [1.5f64, -0.5f64]]
-        );
+        ));
 
-        abs_diff_eq!(a.invert().unwrap() * a, identity);
-        abs_diff_eq!(a * a.invert().unwrap(), identity);
+        assert!(abs_diff_eq!(a.invert().unwrap() * a, identity, epsilon = 0.1));
+        assert!(abs_diff_eq!(a * a.invert().unwrap(), identity));
         assert!(matrix![[0.0f64, 2.0f64], [0.0f64, 5.0f64]]
             .invert()
             .is_none());
@@ -1003,14 +970,14 @@ mod tests {
     #[test]
     fn vec_macro_constructor() {
         let v: Vector<f32, 0> = vector![];
-        assert!(v.is_empty());
+        assert!(v[0].is_empty());
 
         let v = vector![1];
-        assert_eq!(1, v[0]);
+        assert_eq!(1, *v.x());
 
         let v = vector![1, 2, 3, 4, 5, 6, 7, 8, 9, 10,];
         for i in 0..10 {
-            assert_eq!(i + 1, v[i]);
+            assert_eq!(i + 1, v[0][i]);
         }
     }
 
@@ -1019,15 +986,15 @@ mod tests {
         let m: Matrix<f32, 0, 0> = matrix![];
         assert!(m.is_empty());
 
-        let m = matrix![1];
+        let m = matrix![[1]];
         assert_eq!(1, m[0][0]);
 
         let m = matrix![[1, 2], [3, 4], [5, 6],];
         assert_eq!(
             m,
             Matrix::<u32, 3, 2>::from([
-                Vector::<u32, 3>::from([1, 3, 5]),
-                Vector::<u32, 3>::from([2, 4, 6])
+                [1, 3, 5],
+                [2, 4, 6]
             ])
         );
     }
@@ -1035,28 +1002,28 @@ mod tests {
     #[test]
     fn vec_swizzle() {
         let v: Vector<f32, 1> = Vector::<f32, 1>::from([1.0]);
-        assert_eq!(1.0, v.x());
+        assert_eq!(1.0, *v.x());
 
         let v: Vector<f32, 2> = Vector::<f32, 2>::from([1.0, 2.0]);
-        assert_eq!(1.0, v.x());
-        assert_eq!(2.0, v.y());
+        assert_eq!(1.0, *v.x());
+        assert_eq!(2.0, *v.y());
 
         let v: Vector<f32, 3> = Vector::<f32, 3>::from([1.0, 2.0, 3.0]);
-        assert_eq!(1.0, v.x());
-        assert_eq!(2.0, v.y());
-        assert_eq!(3.0, v.z());
+        assert_eq!(1.0, *v.x());
+        assert_eq!(2.0, *v.y());
+        assert_eq!(3.0, *v.z());
 
         let v: Vector<f32, 4> = Vector::<f32, 4>::from([1.0, 2.0, 3.0, 4.0]);
-        assert_eq!(1.0, v.x());
-        assert_eq!(2.0, v.y());
-        assert_eq!(3.0, v.z());
-        assert_eq!(4.0, v.w());
+        assert_eq!(1.0, *v.x());
+        assert_eq!(2.0, *v.y());
+        assert_eq!(3.0, *v.z());
+        assert_eq!(4.0, *v.w());
 
         let v: Vector<f32, 5> = Vector::<f32, 5>::from([1.0, 2.0, 3.0, 4.0, 5.0]);
-        assert_eq!(1.0, v.x());
-        assert_eq!(2.0, v.y());
-        assert_eq!(3.0, v.z());
-        assert_eq!(4.0, v.w());
+        assert_eq!(1.0, *v.x());
+        assert_eq!(2.0, *v.y());
+        assert_eq!(3.0, *v.z());
+        assert_eq!(4.0, *v.w());
     }
 
     #[test]
@@ -1081,14 +1048,14 @@ mod tests {
             y: 0.0,
             z: core::f32::consts::FRAC_PI_2,
         });
-        assert_eq!(rot.rotate_vector(vector![1.0f32, 0.0, 0.0]).y(), 1.0);
+        assert_eq!(*rot.rotate_vector(vector![1.0f32, 0.0, 0.0]).y(), 1.0);
         let v = vector![1.0f32, 0.0, 0.0];
         let q1 = Quaternion::from(Euler {
             x: 0.0,
             y: 0.0,
             z: core::f32::consts::FRAC_PI_2,
         });
-        assert_eq!(q1.rotate_vector(v).normalize().y(), 1.0);
+        assert_eq!(*q1.rotate_vector(v).normalize().y(), 1.0);
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -19,50 +19,63 @@ pub struct Point<T, const N: usize>(pub(crate) [T; N]);
 
 impl<T, const N: usize> Point<T, { N }> {
     /// Convenience method for converting from vector.
-    pub fn from_vec(v: Vector<T, { N }>) -> Self {
-        Self(v.0)
+    pub fn from_vec(Matrix([v]): Vector<T, { N }>) -> Self {
+        Self(v)
     }
 
     /// Convenience method for converting from vector.
     pub fn to_vec(self) -> Vector<T, { N }> {
-        Vector(self.0)
+        Matrix([self.0])
     }
 }
 
-impl<T, const N: usize> Point<T, { N }>
-where
-    T: Clone,
-{
+impl<T, const N: usize> Point<T, { N }> {
     /// Alias for `.get(0).clone()`.
     ///
     /// # Panics
     /// When `N` = 0.
-    pub fn x(&self) -> T {
-        self.0[0].clone()
+    pub fn x(&self) -> &T {
+        &self.0[0]
+    }
+
+    pub fn x_mut(&mut self) -> &mut T {
+        &mut self.0[0]
     }
 
     /// Alias for `.get(1).clone()`.
     ///
     /// # Panics
     /// When `N` < 2.
-    pub fn y(&self) -> T {
-        self.0[1].clone()
+    pub fn y(&self) -> &T {
+        &self.0[1]
+    }
+
+    pub fn y_mut(&mut self) -> &mut T {
+        &mut self.0[1]
     }
 
     /// Alias for `.get(2).clone()`.
     ///
     /// # Panics
     /// When `N` < 3.
-    pub fn z(&self) -> T {
-        self.0[2].clone()
+    pub fn z(&self) -> &T {
+        &self.0[2]
+    }
+
+    pub fn z_mut(&mut self) -> &mut T {
+        &mut self.0[2]
     }
 
     /// Alias for `.get(3).clone()`.
     ///
     /// # Panics
     /// When `N` < 4.
-    pub fn w(&self) -> T {
-        self.0[3].clone()
+    pub fn w(&self) -> &T {
+        &self.0[3]
+    }
+
+    pub fn w_mut(&mut self) -> &mut T {
+        &mut self.0[3]
     }
 }
 
@@ -73,7 +86,7 @@ impl<T, const N: usize> From<[T; N]> for Point<T, { N }> {
 }
 
 impl<T, const N: usize> From<Vector<T, { N }>> for Point<T, { N }> {
-    fn from(Vector(array): Vector<T, { N }>) -> Self {
+    fn from(Matrix([array]): Vector<T, { N }>) -> Self {
         Point::<T, { N }>(array)
     }
 }
@@ -208,9 +221,9 @@ where
     type Output = Point<<A as Add<B>>::Output, { N }>;
 
     fn add(self, rhs: Vector<B, { N }>) -> Self::Output {
-        let lhs = Vector(self.0);
-        let rhs = Vector(rhs.0);
-        Point((lhs + rhs).0)
+        let lhs = Matrix([self.0]);
+        let Matrix([res]) = lhs + rhs;
+        Point(res)
     }
 }
 
@@ -221,9 +234,9 @@ where
     type Output = Point<<A as Sub<B>>::Output, { N }>;
 
     fn sub(self, rhs: Vector<B, { N }>) -> Self::Output {
-        let lhs = Vector(self.0);
-        let rhs = Vector(rhs.0);
-        Point((lhs - rhs).0)
+        let lhs = Matrix([self.0]);
+        let Matrix([res]) = lhs - rhs;
+        Point(res)
     }
 }
 
@@ -234,8 +247,8 @@ where
     type Output = Vector<<A as Sub<B>>::Output, { N }>;
 
     fn sub(self, rhs: Point<B, { N }>) -> Self::Output {
-        let lhs = Vector(self.0);
-        let rhs = Vector(rhs.0);
+        let lhs = Matrix([self.0]);
+        let rhs = Matrix([rhs.0]);
         lhs - rhs
     }
 }

--- a/src/row_view.rs
+++ b/src/row_view.rs
@@ -1,7 +1,6 @@
 //! Support for iterating over matrix rows. This is less natural than
 //! iterating over columns due to the iteration not matching the stride
 //! of the underlying storage.
-
 use super::*;
 
 /// A view into a given row of a matrix. It's possible to index just like a

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -87,8 +87,8 @@ let v = vector!(1i32, 2, 3, 4).xxzz();
 ```
 "##
 )]
-#[repr(transparent)]
-pub struct Vector<T, const N: usize>(pub(crate) [T; N]);
+pub type Vector<T, const N: usize> = Matrix<T, N, 1>;
+//pub struct Vector<T, const N: usize>(pub(crate) [T; N]);
 
 impl<T, const N: usize> Vector<T, { N }> {
     /// Constructs a new vector whose elements are equal to the value of the
@@ -103,14 +103,6 @@ impl<T, const N: usize> Vector<T, { N }> {
             unsafe { top.add(i).write(f(i)) }
         }
         unsafe { to.assume_init() }
-    }
-    /// Applies the given function to each element of the vector, constructing a
-    /// new vector with the returned outputs.
-    pub fn map<Out, F>(self, mut f: F) -> Vector<Out, { N }>
-    where
-        F: FnMut(T) -> Out,
-    {
-        self.indexed_map(|_, x: T| -> Out { f(x) })
     }
 
     pub fn indexed_map<Out, F>(self, mut f: F) -> Vector<Out, { N }>
@@ -131,94 +123,6 @@ impl<T, const N: usize> Vector<T, { N }> {
         }
         unsafe { to.assume_init() }
     }
-
-    /// Converts the Vector into a Matrix with `N` columns each of size `1`.
-    ///
-    /// ```
-    /// # use al_jabr::*;
-    /// let v = vector!(1i32, 2, 3, 4);
-    /// let m = Matrix::<i32, 1, 4>::from([
-    ///     vector!(1i32),
-    ///     vector!(2),
-    ///     vector!(3),
-    ///     vector!(4),
-    /// ]);
-    /// assert_eq!(v.transpose(), m);
-    /// ```
-    pub fn transpose(self) -> Matrix<T, 1, { N }> {
-        let mut from = MaybeUninit::new(self);
-        let mut st = MaybeUninit::<Matrix<T, 1, { N }>>::uninit();
-        let fromp: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut from) };
-        let stp: *mut Vector<T, 1> = unsafe { mem::transmute(&mut st) };
-        for i in 0..N {
-            unsafe {
-                stp.add(i).write(Vector::<T, 1>::from([fromp
-                    .add(i)
-                    .replace(MaybeUninit::uninit())
-                    .assume_init()]));
-            }
-        }
-        unsafe { st.assume_init() }
-    }
-
-    /*
-    /// Removes the last component and returns the vector with one fewer
-    /// dimension.
-    ///
-    /// ```
-    /// # use al_jabr::*;
-    /// let (xyz, w) = vector!(0u32, 1, 2, 3).truncate();
-    /// assert_eq!(xyz, vector!(0u32, 1, 2));
-    /// assert_eq!(w, 3);
-    /// ```
-    pub fn truncate(self) -> (TruncatedVector<T, { N }>, T) {
-        let mut from = MaybeUninit::new(self);
-        let mut head = MaybeUninit::<TruncatedVector<T, { N }>>::uninit();
-        let fromp: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut from) };
-        let headp: *mut T = unsafe { mem::transmute(&mut head) };
-        for i in 0..(N - 1) {
-            unsafe {
-                headp
-                    .add(i)
-                    .write(fromp.add(i).replace(MaybeUninit::uninit()).assume_init());
-            }
-        }
-        (unsafe { head.assume_init() }, unsafe {
-            fromp
-                .add(N - 1)
-                .replace(MaybeUninit::uninit())
-                .assume_init()
-        })
-    }
-    */
-
-    /*
-    /// Extends the vector with an additional value.
-    ///
-    /// Useful for performing affine transformations.
-    /// ```
-    /// # use al_jabr::*;
-    /// let xyzw = vector!(0u32, 1, 2).extend(3);
-    /// assert_eq!(xyzw, vector!(0u32, 1, 2, 3));
-    /// ```
-    pub fn extend(self, new: T) -> ExtendedVector<T, { N }> {
-        let mut from = MaybeUninit::new(self);
-        let mut head = MaybeUninit::<ExtendedVector<T, { N }>>::uninit();
-        let fromp: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut from) };
-        let headp: *mut T = unsafe { mem::transmute(&mut head) };
-        for i in 0..N {
-            unsafe {
-                headp
-                    .add(i)
-                    .write(fromp.add(i).replace(MaybeUninit::uninit()).assume_init());
-            }
-        }
-        unsafe {
-            headp.add(N).write(new);
-            head.assume_init()
-        }
-    }
-    */
 }
 
 /*
@@ -253,7 +157,7 @@ where
         let headp: *mut T = unsafe { mem::transmute(&mut head) };
         for i in 0..M {
             unsafe {
-                headp.add(i).write(self[i].clone());
+                headp.add(i).write(self.0[0][i].clone());
             }
         }
         unsafe { head.assume_init() }
@@ -271,7 +175,7 @@ where
         let tailp: *mut T = unsafe { mem::transmute(&mut tail) };
         for i in 0..M {
             unsafe {
-                tailp.add(i + N - M).write(self[i].clone());
+                tailp.add(i + N - M).write(self.0[0][i].clone());
             }
         }
         unsafe { tail.assume_init() }
@@ -284,13 +188,13 @@ where
 {
     /// Return the cross product of the two vectors.
     pub fn cross(self, rhs: Vector3<T>) -> Self {
-        let [x0, y0, z0]: [T; 3] = self.into();
-        let [x1, y1, z1]: [T; 3] = rhs.into();
-        Vector3::from([
+        let Matrix([[x0, y0, z0]]) = self;
+        let Matrix([[x1, y1, z1]]) = rhs;
+        Vector3::from([[
             (y0.clone() * z1.clone()) - (z0.clone() * y1.clone()),
             (z0 * x1.clone()) - (x0.clone() * z1),
             (x0 * y1) - (y0 * x1),
-        ])
+        ]])
     }
 }
 
@@ -302,11 +206,11 @@ where
     /// associated index.
     pub fn argmax(&self) -> (usize, T) {
         let mut i_max = 0;
-        let mut v_max = self.0[0].clone();
+        let mut v_max = self.0[0][0].clone();
         for i in 1..N {
-            if self.0[i] > v_max {
+            if self.0[0][i] > v_max {
                 i_max = i;
-                v_max = self.0[i].clone();
+                v_max = self.0[0][i].clone();
             }
         }
         (i_max, v_max)
@@ -314,10 +218,10 @@ where
 
     /// Return the largest value in the vector.
     pub fn max(&self) -> T {
-        let mut v_max = self.0[0].clone();
+        let mut v_max = self.0[0][0].clone();
         for i in 1..N {
-            if self.0[i] > v_max {
-                v_max = self.0[i].clone();
+            if self.0[0][i] > v_max {
+                v_max = self.0[0][i].clone();
             }
         }
         v_max
@@ -327,11 +231,11 @@ where
     /// associated index.
     pub fn argmin(&self) -> (usize, T) {
         let mut i_min = 0;
-        let mut v_min = self.0[0].clone();
+        let mut v_min = self.0[0][0].clone();
         for i in 1..N {
-            if self.0[i] < v_min {
+            if self.0[0][i] < v_min {
                 i_min = i;
-                v_min = self.0[i].clone();
+                v_min = self.0[0][i].clone();
             }
         }
         (i_min, v_min)
@@ -339,10 +243,10 @@ where
 
     /// Return the smallest value in the vector.
     pub fn min(&self) -> T {
-        let mut v_min = self.0[0].clone();
+        let mut v_min = self.0[0][0].clone();
         for i in 1..N {
-            if self.0[i] < v_min {
-                v_min = self.0[i].clone();
+            if self.0[0][i] < v_min {
+                v_min = self.0[0][i].clone();
             }
         }
         v_min
@@ -351,14 +255,14 @@ where
 
 impl<T, const N: usize> From<[T; N]> for Vector<T, { N }> {
     fn from(array: [T; N]) -> Self {
-        Vector::<T, { N }>(array)
+        Matrix([array])
     }
 }
 
-impl<T, const N: usize> From<Matrix<T, { N }, 1>> for Vector<T, { N }> {
-    fn from(mat: Matrix<T, { N }, 1>) -> Self {
-        let Matrix([v]) = mat;
-        v
+impl<T, const N: usize> Into<[T; N]> for Vector<T, N> {
+    fn into(self: Vector<T, N>) -> [T; N] {
+        let Matrix([vec]) = self;
+        vec
     }
 }
 
@@ -371,14 +275,6 @@ pub type Vector3<T> = Vector<T, 3>;
 /// 4-element vector.
 pub type Vector4<T> = Vector<T, 4>;
 
-/// Constructs a new vector from an array. Necessary to help the compiler.
-/// Prefer calling the macro `vector!`, which calls `new_vector` internally.
-#[inline]
-#[doc(hidden)]
-pub fn new_vector<T, const N: usize>(elements: [T; N]) -> Vector<T, { N }> {
-    Vector(elements)
-}
-
 /// Construct a new [Vector] of any size.
 ///
 /// ```
@@ -390,121 +286,9 @@ pub fn new_vector<T, const N: usize>(elements: [T; N]) -> Vector<T, { N }> {
 #[macro_export]
 macro_rules! vector {
     ( $($elem:expr),* $(,)? ) => {
-        $crate::new_vector([
-            $($elem),*
-        ])
-    }
-}
-
-impl<T, const N: usize> Clone for Vector<T, { N }>
-where
-    T: Clone,
-{
-    fn clone(&self) -> Self {
-        Vector::<T, { N }>(self.0.clone())
-    }
-}
-
-impl<T, const N: usize> Copy for Vector<T, { N }> where T: Copy {}
-
-impl<T, const N: usize> Into<[T; N]> for Vector<T, { N }> {
-    fn into(self) -> [T; N] {
-        self.0
-    }
-}
-
-impl<T, const N: usize> fmt::Debug for Vector<T, { N }>
-where
-    T: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match N {
-            0 => unimplemented!(),
-            1 => write!(f, "Vector {{ x: {:?} }}", self.0[0]),
-            2 => write!(f, "Vector {{ x: {:?}, y: {:?} }}", self.0[0], self.0[1]),
-            3 => write!(
-                f,
-                "Vector {{ x: {:?}, y: {:?}, z: {:?} }}",
-                self.0[0], self.0[1], self.0[2]
-            ),
-            4 => write!(
-                f,
-                "Vector {{ x: {:?}, y: {:?}, z: {:?}, w: {:?} }}",
-                self.0[0], self.0[1], self.0[2], self.0[3]
-            ),
-            _ => write!(
-                f,
-                "Vector {{ x: {:?}, y: {:?}, z: {:?}, w: {:?}, [..]: {:?} }}",
-                self.0[0],
-                self.0[1],
-                self.0[2],
-                self.0[3],
-                &self.0[4..]
-            ),
-        }
-    }
-}
-
-impl<T, const N: usize> Deref for Vector<T, { N }> {
-    type Target = [T; N];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T, const N: usize> DerefMut for Vector<T, { N }> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<T, const N: usize> Hash for Vector<T, { N }>
-where
-    T: Hash,
-{
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        for i in 0..N {
-            self.0[i].hash(state);
-        }
-    }
-}
-
-impl<T, const N: usize> FromIterator<T> for Vector<T, { N }> {
-    fn from_iter<I>(iter: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let mut iter = iter.into_iter();
-        let mut new = MaybeUninit::<Vector<T, { N }>>::uninit();
-        let newp: *mut T = unsafe { mem::transmute(&mut new) };
-
-        for i in 0..N {
-            if let Some(next) = iter.next() {
-                unsafe { newp.add(i).write(next) };
-            } else {
-                panic!("too few items in iterator to create Vector<_, {}>", N);
-            }
-        }
-
-        if iter.next().is_some() {
-            panic!("too many items in iterator to create Vector<_, {}>", N);
-        }
-
-        unsafe { new.assume_init() }
-    }
-}
-
-impl<T, const N: usize> IntoIterator for Vector<T, { N }> {
-    type Item = T;
-    type IntoIter = ArrayIter<T, { N }>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        let Vector(array) = self;
-        ArrayIter {
-            array: MaybeUninit::new(array),
-            pos:   0,
-        }
+        $crate::matrix![
+            $([ $elem ]),* 
+        ]
     }
 }
 
@@ -516,60 +300,89 @@ impl<T, const N: usize> IntoIterator for Vector<T, { N }> {
 //
 // @maplant: Unfortunately, I think due to a compiler change this is no longer
 // the case. I sure hope it's brought back, however...
-impl<T, const N: usize> Vector<T, { N }>
-where
-    T: Clone,
-{
-    /// Alias for `.get(0).clone()`.
+impl<T, const N: usize> Vector<T, { N }> {
+    /// Alias for `.get(0)`.
     ///
     /// # Panics
     /// When `N` = 0.
-    pub fn x(&self) -> T {
-        self.0[0].clone()
+    pub fn x(&self) -> &T {
+        &self.0[0][0]
     }
 
-    /// Alias for `.get(1).clone()`.
+    pub fn x_mut(&mut self) -> &mut T {
+        &mut self.0[0][0]
+    }
+
+    /// Alias for `.get(1)`.
     ///
     /// # Panics
     /// When `N` < 2.
-    pub fn y(&self) -> T {
-        self.0[1].clone()
+    pub fn y(&self) -> &T {
+        &self.0[0][1]
     }
 
-    /// Alias for `.get(2).clone()`.
+    pub fn y_mut(&mut self) -> &mut T {
+        &mut self.0[0][1]
+    }
+
+    /// Alias for `.get(2)`.
     ///
     /// # Panics
     /// When `N` < 3.
-    pub fn z(&self) -> T {
-        self.0[2].clone()
+    pub fn z(&self) -> &T {
+        &self.0[0][2]
     }
 
-    /// Alias for `.get(3).clone()`.
+    pub fn z_mut(&mut self) -> &mut T {
+        &mut self.0[0][2]
+    }
+
+    /// Alias for `.get(3)`.
     ///
     /// # Panics
     /// When `N` < 4.
-    pub fn w(&self) -> T {
-        self.0[3].clone()
+    pub fn w(&self) -> &T {
+        &self.0[0][3]
+    }
+
+    pub fn w_mut(&mut self) -> &mut T {
+        &mut self.0[0][3]
     }
 
     /// Alias for `.x()`.
-    pub fn r(&self) -> T {
+    pub fn r(&self) -> &T {
         self.x()
     }
 
+    pub fn r_mut(&mut self) -> &mut T {
+        self.x_mut()
+    }
+
     /// Alias for `.y()`.
-    pub fn g(&self) -> T {
+    pub fn g(&self) -> &T {
         self.y()
     }
 
+    pub fn g_mut(&mut self) -> &mut T {
+        self.y_mut()
+    }
+
     /// Alias for `.z()`.
-    pub fn b(&self) -> T {
+    pub fn b(&self) -> &T {
         self.z()
     }
 
+    pub fn b_mut(&mut self) -> &mut T {
+        self.z_mut()
+    }
+
     /// Alias for `.w()`.
-    pub fn a(&self) -> T {
+    pub fn a(&self) -> &T {
         self.w()
+    }
+
+    pub fn a_mut(&mut self) -> &mut T {
+        self.w_mut()
     }
 }
 
@@ -592,8 +405,8 @@ macro_rules! swizzle {
             #[doc(hidden)]
             pub fn [< $a $b >](&self) -> Vector<T, 2> {
                 Vector::<T, 2>::from([
-                    self.$a(),
-                    self.$b(),
+                    self.$a().clone(),
+                    self.$b().clone(),
                 ])
             }
         }
@@ -611,9 +424,9 @@ macro_rules! swizzle {
             #[doc(hidden)]
             pub fn [< $a $b $c >](&self) -> Vector<T, 3> {
                 Vector::<T, 3>::from([
-                    self.$a(),
-                    self.$b(),
-                    self.$c(),
+                    self.$a().clone(),
+                    self.$b().clone(),
+                    self.$c().clone(),
                 ])
             }
         }
@@ -633,10 +446,10 @@ macro_rules! swizzle {
             #[doc(hidden)]
             pub fn [< $a $b $c $d >](&self) -> Vector<T, 4> {
                 Vector::<T, 4>::from([
-                    self.$a(),
-                    self.$b(),
-                    self.$c(),
-                    self.$d(),
+                    self.$a().clone(),
+                    self.$b().clone(),
+                    self.$c().clone(),
+                    self.$d().clone(),
                 ])
             }
         }
@@ -656,242 +469,6 @@ where
     swizzle! {g, r, g, b, a}
     swizzle! {b, r, g, b, a}
     swizzle! {a, r, g, b, a}
-}
-
-impl<T, const N: usize> Zero for Vector<T, { N }>
-where
-    T: Zero,
-{
-    fn zero() -> Self {
-        let mut origin = MaybeUninit::<Vector<T, { N }>>::uninit();
-        let p: *mut T = unsafe { mem::transmute(&mut origin) };
-
-        for i in 0..N {
-            unsafe {
-                p.add(i).write(<T as Zero>::zero());
-            }
-        }
-
-        unsafe { origin.assume_init() }
-    }
-
-    fn is_zero(&self) -> bool {
-        for i in 0..N {
-            if !self.0[i].is_zero() {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-impl<A, B, RHS, const N: usize> PartialEq<RHS> for Vector<A, { N }>
-where
-    RHS: Deref<Target = [B; N]>,
-    A: PartialEq<B>,
-{
-    fn eq(&self, other: &RHS) -> bool {
-        for (a, b) in self.0.iter().zip(other.deref().iter()) {
-            if !a.eq(b) {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-impl<T, const N: usize> Eq for Vector<T, { N }> where T: Eq {}
-
-impl<A, B, const N: usize> Add<Vector<B, { N }>> for Vector<A, { N }>
-where
-    A: Add<B>,
-{
-    type Output = Vector<<A as Add<B>>::Output, { N }>;
-
-    fn add(self, rhs: Vector<B, { N }>) -> Self::Output {
-        let mut sum = MaybeUninit::<[<A as Add<B>>::Output; N]>::uninit();
-        let mut lhs = MaybeUninit::new(self);
-        let mut rhs = MaybeUninit::new(rhs);
-        let sump: *mut <A as Add<B>>::Output = unsafe { mem::transmute(&mut sum) };
-        let lhsp: *mut MaybeUninit<A> = unsafe { mem::transmute(&mut lhs) };
-        let rhsp: *mut MaybeUninit<B> = unsafe { mem::transmute(&mut rhs) };
-        for i in 0..N {
-            unsafe {
-                sump.add(i).write(
-                    lhsp.add(i).replace(MaybeUninit::uninit()).assume_init()
-                        + rhsp.add(i).replace(MaybeUninit::uninit()).assume_init(),
-                );
-            }
-        }
-        Vector::<<A as Add<B>>::Output, { N }>(unsafe { sum.assume_init() })
-    }
-}
-
-impl<A, B, const N: usize> AddAssign<Vector<B, { N }>> for Vector<A, { N }>
-where
-    A: AddAssign<B>,
-{
-    fn add_assign(&mut self, rhs: Vector<B, { N }>) {
-        let mut rhs = MaybeUninit::new(rhs);
-        let rhsp: *mut MaybeUninit<B> = unsafe { mem::transmute(&mut rhs) };
-        for i in 0..N {
-            self.0[i] += unsafe { rhsp.add(i).replace(MaybeUninit::uninit()).assume_init() };
-        }
-    }
-}
-
-impl<A, B, const N: usize> Sub<Vector<B, { N }>> for Vector<A, { N }>
-where
-    A: Sub<B>,
-{
-    type Output = Vector<<A as Sub<B>>::Output, { N }>;
-
-    fn sub(self, rhs: Vector<B, { N }>) -> Self::Output {
-        let mut dif = MaybeUninit::<[<A as Sub<B>>::Output; N]>::uninit();
-        let mut lhs = MaybeUninit::new(self);
-        let mut rhs = MaybeUninit::new(rhs);
-        let difp: *mut <A as Sub<B>>::Output = unsafe { mem::transmute(&mut dif) };
-        let lhsp: *mut MaybeUninit<A> = unsafe { mem::transmute(&mut lhs) };
-        let rhsp: *mut MaybeUninit<B> = unsafe { mem::transmute(&mut rhs) };
-        for i in 0..N {
-            unsafe {
-                difp.add(i).write(
-                    lhsp.add(i).replace(MaybeUninit::uninit()).assume_init()
-                        - rhsp.add(i).replace(MaybeUninit::uninit()).assume_init(),
-                );
-            }
-        }
-        Vector::<<A as Sub<B>>::Output, { N }>(unsafe { dif.assume_init() })
-    }
-}
-
-impl<A, B, const N: usize> SubAssign<Vector<B, { N }>> for Vector<A, { N }>
-where
-    A: SubAssign<B>,
-{
-    fn sub_assign(&mut self, rhs: Vector<B, { N }>) {
-        let mut rhs = MaybeUninit::new(rhs);
-        let rhsp: *mut MaybeUninit<B> = unsafe { mem::transmute(&mut rhs) };
-        for i in 0..N {
-            self.0[i] -= unsafe { rhsp.add(i).replace(MaybeUninit::uninit()).assume_init() };
-        }
-    }
-}
-
-impl<T, const N: usize> Neg for Vector<T, { N }>
-where
-    T: Neg,
-{
-    type Output = Vector<<T as Neg>::Output, { N }>;
-
-    fn neg(self) -> Self::Output {
-        let mut from = MaybeUninit::new(self);
-        let mut neg = MaybeUninit::<[<T as Neg>::Output; N]>::uninit();
-        let fromp: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut from) };
-        let negp: *mut <T as Neg>::Output = unsafe { mem::transmute(&mut neg) };
-        for i in 0..N {
-            unsafe {
-                negp.add(i).write(
-                    fromp
-                        .add(i)
-                        .replace(MaybeUninit::uninit())
-                        .assume_init()
-                        .neg(),
-                );
-            }
-        }
-        Vector::<<T as Neg>::Output, { N }>(unsafe { neg.assume_init() })
-    }
-}
-
-/// Scalar multiply
-impl<A, B, const N: usize> Mul<B> for Vector<A, { N }>
-where
-    A: Mul<B>,
-    B: Clone,
-{
-    type Output = Vector<<A as Mul<B>>::Output, { N }>;
-
-    fn mul(self, scalar: B) -> Self::Output {
-        let mut from = MaybeUninit::new(self);
-        let mut scaled = MaybeUninit::<[<A as Mul<B>>::Output; N]>::uninit();
-        let fromp: *mut MaybeUninit<A> = unsafe { mem::transmute(&mut from) };
-        let scaledp: *mut <A as Mul<B>>::Output = unsafe { mem::transmute(&mut scaled) };
-        for i in 0..N {
-            unsafe {
-                scaledp.add(i).write(
-                    fromp.add(i).replace(MaybeUninit::uninit()).assume_init() * scalar.clone(),
-                );
-            }
-        }
-        Vector::<<A as Mul<B>>::Output, { N }>(unsafe { scaled.assume_init() })
-    }
-}
-
-impl<const N: usize> Mul<Vector<f32, { N }>> for f32 {
-    type Output = Vector<f32, { N }>;
-
-    fn mul(self, vec: Vector<f32, { N }>) -> Self::Output {
-        vec * self
-    }
-}
-
-impl<const N: usize> Mul<Vector<f64, { N }>> for f64 {
-    type Output = Vector<f64, { N }>;
-
-    fn mul(self, vec: Vector<f64, { N }>) -> Self::Output {
-        vec * self
-    }
-}
-
-/// Scalar multiply assign
-impl<A, B, const N: usize> MulAssign<B> for Vector<A, { N }>
-where
-    A: MulAssign<B>,
-    B: Clone,
-{
-    fn mul_assign(&mut self, scalar: B) {
-        for i in 0..N {
-            self.0[i] *= scalar.clone();
-        }
-    }
-}
-
-/// Scalar divide
-impl<A, B, const N: usize> Div<B> for Vector<A, { N }>
-where
-    A: Div<B>,
-    B: Clone,
-{
-    type Output = Vector<<A as Div<B>>::Output, { N }>;
-
-    fn div(self, scalar: B) -> Self::Output {
-        let mut from = MaybeUninit::new(self);
-        let mut scaled = MaybeUninit::<[<A as Div<B>>::Output; N]>::uninit();
-        let fromp: *mut MaybeUninit<A> = unsafe { mem::transmute(&mut from) };
-        let scaledp: *mut <A as Div<B>>::Output = unsafe { mem::transmute(&mut scaled) };
-        for i in 0..N {
-            unsafe {
-                scaledp.add(i).write(
-                    fromp.add(i).replace(MaybeUninit::uninit()).assume_init() / scalar.clone(),
-                );
-            }
-        }
-        Vector::<<A as Div<B>>::Output, { N }>(unsafe { scaled.assume_init() })
-    }
-}
-
-/// Scalar divide assign
-impl<A, B, const N: usize> DivAssign<B> for Vector<A, { N }>
-where
-    A: DivAssign<B>,
-    B: Clone,
-{
-    fn div_assign(&mut self, scalar: B) {
-        for i in 0..N {
-            self.0[i] /= scalar.clone();
-        }
-    }
 }
 
 impl<T, const N: usize> VectorSpace for Vector<T, { N }>
@@ -923,9 +500,6 @@ where
     T: Sub<T, Output = T>,
     T: Mul<T, Output = T>,
     T: Div<T, Output = T>,
-    // TODO: Remove this add assign bound. This is purely for ease of
-    // implementation.
-    T: AddAssign<T>,
     Self: Clone,
 {
     fn dot(self, rhs: Self) -> T {
@@ -935,7 +509,7 @@ where
         let lhsp: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut lhs) };
         let rhsp: *mut MaybeUninit<T> = unsafe { mem::transmute(&mut rhs) };
         for i in 0..N {
-            sum += unsafe {
+            sum = sum + unsafe {
                 lhsp.add(i).replace(MaybeUninit::uninit()).assume_init()
                     * rhsp.add(i).replace(MaybeUninit::uninit()).assume_init()
             };
@@ -944,61 +518,12 @@ where
     }
 }
 
-#[cfg(feature = "rand")]
-impl<T, const N: usize> Distribution<Vector<T, { N }>> for Standard
-where
-    Standard: Distribution<T>,
-{
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Vector<T, { N }> {
-        let mut rand = MaybeUninit::<Vector<T, { N }>>::uninit();
-        let randp: *mut T = unsafe { mem::transmute(&mut rand) };
-
-        for i in 0..N {
-            unsafe { randp.add(i).write(self.sample(rng)) }
-        }
-
-        unsafe { rand.assume_init() }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T, const N: usize> Serialize for Vector<T, { N }>
-where
-    T: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut seq = serializer.serialize_tuple(N)?;
-        for i in 0..N {
-            seq.serialize_element(&self.0[i])?;
-        }
-        seq.end()
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T, const N: usize> Deserialize<'de> for Vector<T, N>
-where
-    T: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer
-            .deserialize_tuple(N, ArrayVisitor::<[T; N]>::new())
-            .map(Vector)
-    }
-}
-
 #[cfg(feature = "mint")]
 impl<T: Copy> Into<mint::Vector2<T>> for Vector<T, 2> {
     fn into(self) -> mint::Vector2<T> {
         mint::Vector2 {
-            x: self.0[0],
-            y: self.0[1],
+            x: self.0[0][0],
+            y: self.0[0][1],
         }
     }
 }
@@ -1006,7 +531,7 @@ impl<T: Copy> Into<mint::Vector2<T>> for Vector<T, 2> {
 #[cfg(feature = "mint")]
 impl<T> From<mint::Vector2<T>> for Vector<T, 2> {
     fn from(mint_vec: mint::Vector2<T>) -> Self {
-        Vector([mint_vec.x, mint_vec.y])
+        Matrix([[mint_vec.x, mint_vec.y]])
     }
 }
 
@@ -1014,9 +539,9 @@ impl<T> From<mint::Vector2<T>> for Vector<T, 2> {
 impl<T: Copy> Into<mint::Vector3<T>> for Vector<T, 3> {
     fn into(self) -> mint::Vector3<T> {
         mint::Vector3 {
-            x: self.0[0],
-            y: self.0[1],
-            z: self.0[2],
+            x: self.0[0][0],
+            y: self.0[0][1],
+            z: self.0[0][2],
         }
     }
 }
@@ -1024,7 +549,7 @@ impl<T: Copy> Into<mint::Vector3<T>> for Vector<T, 3> {
 #[cfg(feature = "mint")]
 impl<T> From<mint::Vector3<T>> for Vector<T, 3> {
     fn from(mint_vec: mint::Vector3<T>) -> Self {
-        Vector([mint_vec.x, mint_vec.y, mint_vec.z])
+        Matrix([[mint_vec.x, mint_vec.y, mint_vec.z]])
     }
 }
 
@@ -1032,10 +557,10 @@ impl<T> From<mint::Vector3<T>> for Vector<T, 3> {
 impl<T: Copy> Into<mint::Vector4<T>> for Vector<T, 4> {
     fn into(self) -> mint::Vector4<T> {
         mint::Vector4 {
-            x: self.0[0],
-            y: self.0[1],
-            z: self.0[2],
-            w: self.0[3],
+            x: self.0[0][0],
+            y: self.0[0][1],
+            z: self.0[0][2],
+            w: self.0[0][3],
         }
     }
 }
@@ -1043,6 +568,6 @@ impl<T: Copy> Into<mint::Vector4<T>> for Vector<T, 4> {
 #[cfg(feature = "mint")]
 impl<T> From<mint::Vector4<T>> for Vector<T, 4> {
     fn from(mint_vec: mint::Vector4<T>) -> Self {
-        Vector([mint_vec.x, mint_vec.y, mint_vec.z, mint_vec.w])
+        Matrix([[mint_vec.x, mint_vec.y, mint_vec.z, mint_vec.w]])
     }
 }

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -3,7 +3,7 @@ use al_jabr::{matrix, vector, Matrix, Vector};
 #[test]
 fn test_serialize() {
     let v = vector![1u32, 2, 3, 4, 5, 6, 7];
-    assert_eq!(serde_json::to_string(&v).unwrap(), "[1,2,3,4,5,6,7]");
+    assert_eq!(serde_json::to_string(&v).unwrap(), "[[1,2,3,4,5,6,7]]");
     let m = matrix![[1u32, 2], [3u32, 4],];
     assert_eq!(serde_json::to_string(&m).unwrap(), "[[1,3],[2,4]]");
 }
@@ -11,7 +11,7 @@ fn test_serialize() {
 // Doesn't currently work due to a compiler bug.
 #[test]
 fn test_deserialize() {
-    let v: Vector<u32, 7> = serde_json::from_str(&"[1,2,3,4,5,6,7]").unwrap();
+    let v: Vector<u32, 7> = serde_json::from_str(&"[[1,2,3,4,5,6,7]]").unwrap();
     assert_eq!(v, vector![1u32, 2, 3, 4, 5, 6, 7],);
     let m: Matrix<u32, 2, 2> = serde_json::from_str(&"[[1,3],[2,4]]").unwrap();
     assert_eq!(m, matrix![[1u32, 2], [3u32, 4],],);


### PR DESCRIPTION
This is opposed to the previous definition, which defined Matrices in terms of Vectors. This is a much more natural definition and dramatically reduces the amount of code for the same implementation. 